### PR TITLE
feat: add base helper functions for fonts and styles

### DIFF
--- a/src/helpers/colorHelpers.ts
+++ b/src/helpers/colorHelpers.ts
@@ -1,0 +1,123 @@
+/*
+ * Interfaces.
+ */
+
+interface FullColorPalette {
+  readonly white: string;
+  readonly shade10: string;
+  readonly shade20: string;
+  readonly shade30: string;
+  readonly shade40: string;
+  readonly shade50: string;
+  readonly shade60: string;
+  readonly shade70: string;
+  readonly shade80: string;
+  readonly shade90: string;
+  readonly black: string;
+}
+
+export interface PaletteColor {
+  readonly shade10: string;
+  readonly shade20: string;
+  readonly shade30: string;
+  readonly shade40: string;
+  readonly shade50: string;
+}
+
+type Palette = {readonly [T in PaletteColorsEnum]: PaletteColor};
+
+/*
+ * Constants.
+ */
+
+export enum PaletteColorsEnum {
+  GREY = 'grey',
+  PINK = 'pink',
+  RED = 'red',
+  ORANGE = 'orange',
+  YELLOW = 'yellow',
+  GREEN = 'green',
+  TEAL = 'teal',
+  BLUE = 'blue',
+  PURPLE = 'purple'
+}
+
+export const greys: Readonly<FullColorPalette> = {
+  white: '#ffffff',
+  shade10: '#f7f8fa',
+  shade20: '#f3f4f6',
+  shade30: '#e8eaed',
+  shade40: '#d4d6d9',
+  shade50: '#bbbdbf',
+  shade60: '#9b9c9e',
+  shade70: '#77787a',
+  shade80: '#3e3e40',
+  shade90: '#19191a',
+  black: '#001B38'
+};
+
+export const palette: Palette = {
+  [PaletteColorsEnum.GREY]: {
+    shade10: greys.shade10,
+    shade20: greys.shade30,
+    shade30: greys.shade50,
+    shade40: greys.shade70,
+    shade50: greys.shade80
+  },
+  [PaletteColorsEnum.PINK]: {
+    shade10: '#fdf0f8',
+    shade20: '#fbe1f2',
+    shade30: '#f8cae8',
+    shade40: '#ca3e99',
+    shade50: '#9f3079'
+  },
+  [PaletteColorsEnum.RED]: {
+    shade10: '#fff1f1',
+    shade20: '#ffe1de',
+    shade30: '#fac1bb',
+    shade40: '#e9483a',
+    shade50: '#b72215'
+  },
+  [PaletteColorsEnum.ORANGE]: {
+    shade10: '#fff7f0',
+    shade20: '#ffe9d1',
+    shade30: '#fadab9',
+    shade40: '#f2830b',
+    shade50: '#cc6000'
+  },
+  [PaletteColorsEnum.YELLOW]: {
+    shade10: '#fefbef',
+    shade20: '#fef6dc',
+    shade30: '#faebbb',
+    shade40: '#e3b51e',
+    shade50: '#91691b'
+  },
+  [PaletteColorsEnum.GREEN]: {
+    shade10: '#eefbf3',
+    shade20: '#d9f6e3',
+    shade30: '#b6f0ca',
+    shade40: '#10aa40',
+    shade50: '#0c8331'
+  },
+  [PaletteColorsEnum.TEAL]: {
+    shade10: '#f0fdff',
+    shade20: '#dcfbff',
+    shade30: '#b9f2fa',
+    shade40: '#15acc0',
+    shade50: '#0d7482'
+  },
+  [PaletteColorsEnum.BLUE]: {
+    shade10: '#f1f6fd',
+    shade20: '#e0edff',
+    shade30: '#bed7fa',
+    shade40: '#367fee',
+    shade50: '#2356b3'
+  },
+  [PaletteColorsEnum.PURPLE]: {
+    shade10: '#f8f1ff',
+    shade20: '#f0dfff',
+    shade30: '#ddbbfa',
+    shade40: '#9235e4',
+    shade50: '#681aad'
+  }
+};

--- a/src/helpers/fontHelpers.ts
+++ b/src/helpers/fontHelpers.ts
@@ -1,0 +1,80 @@
+/*
+ * Interfaces.
+ */
+
+interface FontSizes {
+  readonly veryTiny: string;
+  readonly tiny: string;
+  readonly verySmall: string;
+  readonly small: string;
+  readonly medium: string;
+  readonly large: string;
+  readonly veryLarge: string;
+}
+
+interface FontWeights {
+  readonly thin: number;
+  readonly light: number;
+  readonly normal: number;
+  readonly medium: number;
+  readonly semibold: number;
+  readonly bold: number;
+  readonly black: number;
+}
+
+interface Fonts {
+  readonly system: string;
+  readonly monospace: string;
+}
+
+/*
+ * Constants.
+ */
+
+export const fontSizes: FontSizes = {
+  veryTiny: '10px',
+  tiny: '11px',
+  verySmall: '12px',
+  small: '13px',
+  medium: '14px',
+  large: '16px',
+  veryLarge: '18px'
+};
+
+export const fontWeights: FontWeights = {
+  thin: 100,
+  light: 300,
+  normal: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  black: 800
+};
+
+export enum VisualSizesEnum {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+  EXTRA_LARGE = 'extra-large'
+}
+
+export const fonts: Fonts = {
+  system: `
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol"
+  `,
+  monospace: `
+    monaco,
+    Consolas,
+    "Lucida Console",
+    monospace
+  `
+};

--- a/src/helpers/styleHelpers.ts
+++ b/src/helpers/styleHelpers.ts
@@ -1,0 +1,65 @@
+import {VisualSizesEnum} from "./fontHelpers";
+
+/*
+ * Interfaces.
+ */
+
+export interface SelectableComponentColors {
+  textColor: string
+  hoverTextColor?: string;
+  selectedTextColor?: string;
+  disabledTextColor?: string;
+  backgroundColor: string
+  hoverBackgroundColor?: string;
+  selectedBackgroundColor?: string;
+  disabledBackgroundColor?: string;
+}
+
+/*
+ * Helpers.
+ */
+
+/**
+ * Wrapper to easily assign constant values to the different VisualSizesEnums.
+ */
+export type VisualSizeConstants<T> = {readonly [K in VisualSizesEnum]: T};
+export function makeSizeConstants<T>(smallVariant: T, ...variants: T[]): VisualSizeConstants<T> {
+  return {
+    [VisualSizesEnum.SMALL]: smallVariant,
+    [VisualSizesEnum.MEDIUM]: variants[0] || smallVariant,
+    [VisualSizesEnum.LARGE]: variants[1] || variants[0] || smallVariant,
+    [VisualSizesEnum.EXTRA_LARGE]: variants[2] || variants[1] || variants[0] || smallVariant
+  };
+}
+
+/**
+ * Get the color for the specified text type. If the type is not defined, it will fallback to the textColor.
+ */
+export function getTextColorFromStyles(styles: SelectableComponentColors, type?: 'hover' | 'selected' | 'disabled') {
+  if (!type)
+    return styles.textColor;
+
+  if (type === 'hover')
+    return styles.hoverTextColor ?? styles.textColor;
+  if (type === 'selected')
+    return styles.selectedTextColor ?? styles.textColor;
+  if (type === 'disabled')
+    return styles.disabledTextColor ?? styles.textColor;
+  return styles.textColor;
+}
+
+/**
+ * Get the color for the specified background type. If the type is not defined, it will fallback to the backgroundColor.
+ */
+export function getBackgroundColorFromStyles(styles: SelectableComponentColors, type?: 'hover' | 'selected' | 'disabled') {
+  if (!type)
+    return styles.backgroundColor;
+
+  if (type === 'hover')
+    return styles.hoverBackgroundColor ?? styles.backgroundColor;
+  if (type === 'selected')
+    return styles.selectedBackgroundColor ?? styles.backgroundColor;
+  if (type === 'disabled')
+    return styles.disabledBackgroundColor ?? styles.backgroundColor;
+  return styles.backgroundColor;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-import FrontLogo from './assets/FrontLogo.svg';
+/*
+ * Interfaces.
+ */
 
-export const testFront = 'testFront';
-export const frontLogoSrc = FrontLogo;
+export {SelectableComponentColors} from './helpers/styleHelpers';
+
+/*
+ * Constants.
+ */
+
+export {VisualSizesEnum, fonts} from './helpers/fontHelpers';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmitOnError": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "emitDecoratorMetadata": true,
     "noUnusedLocals": true,
     "sourceMap": true,


### PR DESCRIPTION
### Description

This adds in the base helper functions that are needed from most of the components. Adds in new exposed values of:

- `SelectableComponentColors`: which is a simple interface for specifying colors for different parts of a component.
- `VisualSizesEnum`: Which will enable passing sizes to components.
- `fonts`: To allow developers to use the same fonts for if they have any custom components.