### PR TITLE
ci: pre v1 settings needed

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,7 +15,6 @@ jobs:
         id: release
         with:
           release-type: node
-          extra-files: README.md
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
 


### PR DESCRIPTION
### Description

Looking at the version here https://github.com/frontapp/front-ui-kit/pull/10 it is bumping a major version and we need to not do that until we are ready to release.

This fixes that.

https://github.com/google-github-actions/release-please-action#configuration