### PR TITLE
ci: update initial release

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,11 +1,9 @@
 name: Build and Publish
 
 on:
-  push
-# on:
-#   push:
-#     branches:
-#       - main
+  push:
+    branches:
+      - main
 
 jobs:
   release-please:


### PR DESCRIPTION
Looks like release-please is still trying to release v1.0.0 instead of v0.1.0 which it should based on settings. Adding more here to try and get it to work.

Example PR https://github.com/frontapp/front-ui-kit/pull/12 it created