### PR TITLE
ci: remove the command for release-please

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          command: release-pr
           release-type: node
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true


### PR DESCRIPTION
https://github.com/frontapp/front-ui-kit/runs/6294539485?check_suite_focus=true

looks like we didn't release anything with that. I _think_ it is because of the command specified. Will try again.