### PR TITLE
feat: add avatar component

### DIFF
--- a/src/components/avatar/__docs__/avatar.stories.tsx
+++ b/src/components/avatar/__docs__/avatar.stories.tsx
@@ -1,0 +1,25 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React from 'react';
+
+import {VisualSizesEnum} from '../../../helpers/fontHelpers';
+import {Avatar} from '../avatar';
+
+export default {
+  title: 'Front UI Kit/Avatar',
+  component: Avatar
+} as ComponentMeta<typeof Avatar>;
+
+const Template: ComponentStory<typeof Avatar> = args => <Avatar {...args} />;
+
+export const InitialsAvatar = Template.bind({});
+InitialsAvatar.args = {
+  name: "John Doe"
+};
+
+export const ImageAvatar = Template.bind({});
+ImageAvatar.args = {
+  name: "John Doe",
+  // Example image supplied by: https://picsum.photos/
+  imgSrc: "https://picsum.photos/id/1062/200/200",
+  size: VisualSizesEnum.EXTRA_LARGE
+};

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -1,0 +1,98 @@
+import React, {FC, useMemo} from 'react';
+import styled, {css} from 'styled-components';
+
+import {greys, palette, PaletteColorsEnum} from '../../helpers/colorHelpers';
+import {fonts, fontSizes, VisualSizesEnum} from '../../helpers/fontHelpers';
+import {makeSizeConstants} from '../../helpers/styleHelpers';
+
+/*
+ * Constants.
+ */
+
+const avatarSizes = makeSizeConstants(16, 20, 30, 48);
+const lineHeights = makeSizeConstants(16, 20, 30, 48);
+const avatarFontSizes = makeSizeConstants(fontSizes.tiny, fontSizes.tiny, fontSizes.small, fontSizes.large);
+const characterLimits = makeSizeConstants(1, 2);
+
+/*
+ * Props.
+ */
+
+interface AvatarProps {
+  /** The name to use for the avatar. */
+  name: string;
+  /** If specified, we will render the image instead of initials. */
+  imgSrc?: string;
+  /** The size of the avatar. Defaults to VisualSizesEnum.LARGE. */
+  size?: VisualSizesEnum;
+}
+
+/*
+ * Style.
+ */
+
+interface StyledAvatarWrapperDivProps {
+  $color: string;
+  $size: VisualSizesEnum;
+  $imgSrc?: string;
+}
+
+const StyledAvatarWrapperDiv = styled.div<StyledAvatarWrapperDivProps>`
+  font-family: ${fonts.system};
+  width: ${p => `${avatarSizes[p.$size]}px`};
+  height: ${p => `${avatarSizes[p.$size]}px`};
+  line-height: ${p => `${lineHeights[p.$size]}px`};
+  font-size: ${p => avatarFontSizes[p.$size]};
+  background: ${p => p.$color};
+  border-radius: 50%;
+  text-align: center;
+  color: ${greys.white};
+
+  ${p => addImageSrcStyles(p.$imgSrc)};
+`;
+
+function addImageSrcStyles(imgSrc?: string) {
+  if (!imgSrc)
+    return '';
+  return css`
+    background: transparent;
+    background-image: url(${imgSrc});
+    background-size: cover;
+    background-position: center center;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+  `;
+}
+
+/*
+ * Component.
+ */
+
+export const Avatar: FC<AvatarProps> = props => {
+  const {name, imgSrc, size = VisualSizesEnum.LARGE} = props;
+  const avatarColor = useMemo(() => computeColorFromName(name.trim()), [name]);
+  const initials = useMemo(() => computeInitialsFromName(name.trim(), size), [name, size]);
+
+  return <StyledAvatarWrapperDiv $color={avatarColor} $size={size} $imgSrc={imgSrc}>{!imgSrc && initials}</StyledAvatarWrapperDiv>;
+};
+
+/*
+ * Helpers.
+ */
+
+function computeColorFromName(name: string) {
+  if (name.length === 0)
+    return palette.blue.shade40;
+  // Count the list of available colors and remove 1 since we do not allow grey as a default color.
+  const availableColorsCount = Object.keys(palette).length - 1;
+  const selectedColorIndex = ((name.length * name.charCodeAt(0) * name.charCodeAt(name.length - 1)) % availableColorsCount) + 1;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const selectedColorPalette = Object.keys(palette)[selectedColorIndex] as PaletteColorsEnum;
+  return palette[selectedColorPalette].shade40;
+}
+
+function computeInitialsFromName(name: string, size: VisualSizesEnum) {
+  const initialLimits = characterLimits[size];
+  return name.split(' ').map(word => word[0]).slice(0, initialLimits).join('');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,6 @@ export {VisualSizesEnum, fonts} from './helpers/fontHelpers';
  * Components.
  */
 
+export {Avatar} from './components/avatar/avatar';
+
 export {Icon, IconName} from './components/icon/icon';


### PR DESCRIPTION
## Component

`<Avatar />`

## Description

This adds the avatar component which supports pulling the initials from the name or using an image as a source. This is a relatively simple component, so there are only two new stories that were added.

## Images

![2022-05-04 13 22 56](https://user-images.githubusercontent.com/36998210/166810999-c1b2b4fe-31fa-4112-8515-49740d30f1a6.gif)
