### PR TITLE
feat: add Tab and TabGroup components

### DIFF
--- a/src/components/tab/__docs__/tab-group.stories.tsx
+++ b/src/components/tab/__docs__/tab-group.stories.tsx
@@ -1,0 +1,33 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {useState} from 'react';
+
+import {Tab} from '../tab';
+import {TabGroup} from '../tabGroup';
+
+export default {
+  title: 'Front UI Kit/Tabs',
+  component: TabGroup
+} as ComponentMeta<typeof TabGroup>;
+
+const tabs = [
+  "Example Tab 1",
+  "Example Tab 2",
+  "Example Tab 3"
+];
+
+const Template: ComponentStory<typeof Tab> = args => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+
+  return (
+    <TabGroup {...args}>
+      {tabs.map(tab => (
+        <Tab key={tab} name={tab} isSelected={tab === selectedTab} onClick={() => setSelectedTab(tab)} />
+      ))}
+    </TabGroup>
+  );
+};
+
+export const Group = Template.bind({});
+Group.args = {
+  maxWidth: 400
+};

--- a/src/components/tab/__docs__/tab.stories.tsx
+++ b/src/components/tab/__docs__/tab.stories.tsx
@@ -1,0 +1,17 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React from 'react';
+
+import {Tab} from '../tab';
+
+export default {
+  title: 'Front UI Kit/Tabs',
+  component: Tab
+} as ComponentMeta<typeof Tab>;
+
+const Template: ComponentStory<typeof Tab> = args => <Tab {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  name: "Example Tab",
+  isSelected: false
+};

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -1,0 +1,82 @@
+import {ellipsis} from 'polished';
+import React, {FC, MouseEventHandler} from 'react';
+import styled, {css} from 'styled-components';
+
+import {alphas, greys} from '../../helpers/colorHelpers';
+import {fonts, fontWeights} from '../../helpers/fontHelpers';
+
+/*
+ * Props.
+ */
+
+interface TabProps {
+  /** The name of the tab. */
+  name: string;
+  /** Whether the tab is selected. */
+  isSelected?: boolean;
+  /** Called when the tab is clicked. */
+  onClick?: MouseEventHandler;
+}
+
+/*
+ * Style.
+ */
+
+interface StyledTabWrapperDivProps {
+  $isSelected?: boolean;
+}
+
+const StyledTabWrapperDiv = styled.div<StyledTabWrapperDivProps>`
+  display: inline-block;
+  flex: 1;
+  font-family: ${fonts.system};
+  position: relative;
+  font-weight: ${fontWeights.semibold};
+  color: ${greys.shade60};
+  overflow: hidden;
+  cursor: default;
+  text-align: center;
+
+  ${p => p.$isSelected && css`
+    color: ${greys.black};
+  `}
+
+  &:hover {
+    color: ${greys.black};
+  }
+`;
+
+const StyledTabNameDiv = styled.div`
+  margin-bottom: 12px;
+  ${ellipsis()}; // TODO: Remove this when we have tooltip support.
+`;
+
+interface StyledSelectedBorderDivProps {
+  $isSelected?: boolean;
+}
+
+const StyledSelectedBorderDiv = styled.div<StyledSelectedBorderDivProps>`
+  background: ${alphas.transparent};
+  height: 4px;
+  border-top-left-radius: 100px;
+  border-top-right-radius: 100px;
+
+  ${p => p.$isSelected && css`
+    background: ${greys.black};
+  `}
+`;
+
+/*
+ * Component.
+ */
+
+// TODO: Add tooltip support for overflowing names.
+export const Tab: FC<TabProps> = props => {
+  const {name, isSelected, onClick} = props;
+  return (
+    <StyledTabWrapperDiv $isSelected={isSelected} onClick={onClick}>
+      <StyledTabNameDiv>{name}</StyledTabNameDiv>
+      <StyledSelectedBorderDiv $isSelected={isSelected} />
+    </StyledTabWrapperDiv>
+  );
+};

--- a/src/components/tab/tabGroup.tsx
+++ b/src/components/tab/tabGroup.tsx
@@ -1,0 +1,57 @@
+import React, {FC} from 'react';
+import * as ReactIs from "react-is";
+import styled from 'styled-components';
+
+/*
+ * Props.
+ */
+
+interface TabGroupProps {
+  /** Tabs to render. Only will render the Tab component. */
+  children?: React.ReactNode;
+  /** Max width of the group. Defaults to 100% of parent. */
+  maxWidth?: number;
+}
+
+/*
+ * Style.
+ */
+
+interface StyledTabGroupWrapperDivProps {
+  $maxWidth?: number;
+}
+
+const StyledTabGroupWrapperDiv = styled.div<StyledTabGroupWrapperDivProps>`
+  display: flex;
+  flex-flow: row;
+  gap: 16px;
+  max-width: ${p => (p.$maxWidth ? `${p.$maxWidth}px` : '100%')};
+`;
+
+/*
+ * Component.
+ */
+
+export const TabGroup: FC<TabGroupProps> = ({children, maxWidth}) => (
+  <StyledTabGroupWrapperDiv $maxWidth={maxWidth}>{renderTabGroupContent(children)}</StyledTabGroupWrapperDiv>
+);
+
+/*
+ * Helpers.
+ */
+
+function renderTabGroupContent(children: React.ReactNode) {
+  return React.Children.toArray(children).map(child => {
+    if (typeof child === 'string' || typeof child === 'number')
+      return null;
+    if (ReactIs.isFragment(child) || !ReactIs.isElement(child))
+      return null;
+
+    // Only allow tabs to be rendered.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
+    if ((child.type as any)?.displayName === 'Tab')
+      return child;
+
+    return null;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,6 @@ export {ButtonGroup} from './components/button/buttonGroup';
 export {Icon, IconName} from './components/icon/icon';
 
 export {Skeleton} from './components/skeleton/skeleton';
+
+export {Tab} from './components/tab/tab';
+export {TabGroup} from './components/tab/tabGroup';


### PR DESCRIPTION
## Components

- `<Tab />`
- `<TabGroup />`

## Description

Adds in the tab and tab group components. This is a slimmed down version from the main frontend codebase as we do not need the custom logic around there. TabGroup only supports rendering Tabs and anything else passed in will be ignored.

There are some TODOs to add here when https://github.com/frontapp/front-ui-kit/pull/27 is merged.

## Images

![2022-05-06 10 57 46](https://user-images.githubusercontent.com/36998210/167179495-5f27e249-2032-4ac8-9ca5-4933bb4bff10.gif)
