### PR TITLE
fix: add displayName to prod build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-const WebpackReactComponentNamePlugin = require('webpack-react-component-name');
 const path = require('path');
 
 const isProduction = process.argv.indexOf('--mode=production') !== -1;


### PR DESCRIPTION
Some of the internal logic requires the displayName to be there. This adds it in so when we do a build it produces the display name