### PR TITLE
test: add tooltip tests

### DIFF
--- a/src/components/tooltip/__docs__/tooltipCoordinator.stories.tsx
+++ b/src/components/tooltip/__docs__/tooltipCoordinator.stories.tsx
@@ -7,7 +7,7 @@ import {VisualSizesEnum} from '../../../helpers/fontHelpers';
 import {DefaultStyleProvider} from '../../../utils/defaultStyleProvider';
 import {Avatar} from '../../avatar/avatar';
 import {Button} from '../../button/button';
-import {Tooltip} from '../../tooltip/tooltip';
+import {Tooltip} from '../tooltip';
 import {TooltipCoordinator} from '../tooltipCoordinator';
 
 const StyledExampleWrapperDiv = styled.div`

--- a/src/components/tooltip/__tests__/tooltip.spec.tsx
+++ b/src/components/tooltip/__tests__/tooltip.spec.tsx
@@ -1,0 +1,56 @@
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {Tooltip} from '../tooltip';
+import {TooltipCoordinator} from '../tooltipCoordinator';
+
+describe('<Tooltip /> Spec', () => {
+  it('should show tooltip when hovered', async () => {
+    render((
+      <TooltipCoordinator renderTooltip={() => <Tooltip>Example Tooltip</Tooltip>}>
+        <div>anchor</div>
+      </TooltipCoordinator>
+    ));
+
+    // Hover over the anchor.
+    await userEvent.hover(screen.getByText('anchor'));
+    // Make sure the tooltip is visible.
+    await waitFor(() => {
+      const tooltip = screen.queryByText('Example Tooltip');
+      expect(tooltip).not.toBeNull();
+    });
+  });
+
+  it('should not render tooltip when hovered when explicit condition is not enabled.', async () => {
+    render((
+      <TooltipCoordinator renderTooltip={() => <Tooltip>Example Tooltip</Tooltip>} condition={{type: 'explicit', isEnabled: false}}>
+        <div>anchor</div>
+      </TooltipCoordinator>
+    ));
+
+    // Hover over the anchor.
+    await userEvent.hover(screen.getByText('anchor'));
+    await act(() => {});
+
+    // Make sure the tooltip is not visible.
+    const tooltip = screen.queryByText('Example Tooltip');
+    expect(tooltip).toBeNull();
+  });
+
+  it('should render tooltip when hovered when explicit condition is enabled.', async () => {
+    render((
+      <TooltipCoordinator renderTooltip={() => <Tooltip>Example Tooltip</Tooltip>} condition={{type: 'explicit', isEnabled: true}}>
+        <div>anchor</div>
+      </TooltipCoordinator>
+    ));
+
+    // Hover over the anchor.
+    await userEvent.hover(screen.getByText('anchor'));
+    // Make sure the tooltip is visible.
+    await waitFor(() => {
+      const tooltip = screen.queryByText('Example Tooltip');
+      expect(tooltip).not.toBeNull();
+    });
+  });
+});

--- a/src/components/tooltip/tooltipCoordinator.tsx
+++ b/src/components/tooltip/tooltipCoordinator.tsx
@@ -2,8 +2,8 @@ import React, {FC, useEffect, useState} from 'react';
 import styled from 'styled-components';
 
 import {useTimeout} from '../../helpers/hookHelpers';
-import {TooltipOverflow} from '../tooltip/tooltipOverflow';
-import {PopoverContext, PopoverContextProps} from './popoverContext';
+import {PopoverContext, PopoverContextProps} from '../popover/popoverContext';
+import {TooltipOverflow} from './tooltipOverflow';
 
 /*
  * Tooltip Conditions.

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,4 +47,4 @@ export {TabGroup} from './components/tab/tabGroup';
 export {Textarea} from './components/textarea/textarea';
 
 export {Tooltip} from './components/tooltip/tooltip';
-export {TooltipCoordinator} from './components/popover/tooltipCoordinator';
+export {TooltipCoordinator} from './components/tooltip/tooltipCoordinator';


### PR DESCRIPTION
### Description

This adds in tests for the tooltip. This tests:
- Rendering a tooltip with no condition
- Rendering a tooltip with explicit condition false
- Rendering a tooltip with explicit condition true

Note we can not test the overflow condition unless we implement some testing via Cypress or something else since JSDom doesn't do any layout so the scrollWidth checks will always be 0.