### PR TITLE
revert: feat! Remove optional state for the value in the onChange handler for input & textarea

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -31,7 +31,7 @@ interface InputProps {
   /** Max width of the input. Default is 100%. */
   maxWidth?: number;
   /** The handler for when the content of the input field changes */
-  onChange?: (value: string | number) => void;
+  onChange?: (value?: string | number) => void;
   /** The handler for when the input field is unfocused */
   onBlur?: () => void;
   /** The handler for when the input field is focused */

--- a/src/components/textarea/textarea.tsx
+++ b/src/components/textarea/textarea.tsx
@@ -30,7 +30,7 @@ interface TextareaProps {
   /** Max width of the textarea. Default is 100%. */
   maxWidth?: number;
   /** The handler for when the content of the textarea field changes */
-  onChange?: (value: string) => void;
+  onChange?: (value?: string) => void;
   /** The handler for when the textarea field is unfocused */
   onBlur?: () => void;
   /** The handler for when the textarea field is focused */


### PR DESCRIPTION
This reverts commit 64eea87bbd0d671bc7986edeea3a867fbc893e95 since the commit name doesn't follow the conventional commit format. The title ""feat! Remove the optional state for the argument for the onChange handler for the input and textarea components (#57)" is missing a `:` after the `!`