### PR TITLE
feat: add description to dropdownItem

### DIFF
--- a/src/components/dropdown/__docs__/multilineAsync.stories.tsx
+++ b/src/components/dropdown/__docs__/multilineAsync.stories.tsx
@@ -1,0 +1,84 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {useState} from 'react';
+
+import {Button} from '../../button/button';
+import {Icon} from '../../icon/icon';
+import {Dropdown} from '../dropdown';
+import {DropdownCoordinator} from '../dropdownCoordinator';
+import {DropdownItem} from '../dropdownItem';
+import {DropdownItemSkeleton} from '../skeleton/dropdownItemSkeleton';
+import {disabledDropdownStoryFields} from './dropdownStoryHelpers';
+
+interface UserData {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export default {
+  title: 'Components/Dropdown',
+  component: Dropdown,
+  argTypes: {
+    ...disabledDropdownStoryFields
+  }
+} as ComponentMeta<typeof Dropdown>;
+
+const Template: ComponentStory<typeof Dropdown> = args => {
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [users, setUsers] = useState<ReadonlyArray<UserData>>([]);
+
+  const fetchUserData = async () => {
+    if (isLoading)
+      return;
+    setIsLoading(true);
+    // Create a 1 second delay between requests.
+    setTimeout(async () => {
+      const data = await fetch(`https://randomuser.me/api/?page=${page}&results=15`);
+      const jsonData = await data.json();
+      setUsers(existingUsers => [...existingUsers, ...jsonData.results.map(d => ({
+        id: d.login.uuid,
+        name: `${d.name.first} ${d.name.last}`,
+        email: d.email
+      }))]);
+      setPage(currentPage => currentPage + 1);
+      setIsLoading(false);
+    }, 1000);
+  };
+
+  return (
+    <DropdownCoordinator
+      {...args}
+      placement="bottom-start"
+      renderButton={() => <Button type="icon"><Icon name="EllipsisVertical" /></Button>}
+      onDropdownClosed={() => {
+        setPage(1);
+        setIsLoading(false);
+        setUsers([]);
+      }}
+      renderDropdown={() => (
+        <Dropdown
+          {...args}
+          isLoading={isLoading}
+          hasMore={page < 5}
+          onLoadMore={fetchUserData}
+          loadingSkeleton={<DropdownItemSkeleton hasDescription />}
+        >
+          {users.map(user => (
+            <DropdownItem
+              key={user.id}
+              description={user.email}
+              onClick={() => console.log('Selected user:', user)}
+            >
+              {user.name}
+            </DropdownItem>
+          ))}
+        </Dropdown>
+      )}
+    />
+  );
+};
+export const MultiLine = Template.bind({});
+MultiLine.args = {
+  loadingThreshold: 3
+};

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -14,6 +14,7 @@ import {DropdownItemSkeleton} from './skeleton/dropdownItemSkeleton';
 const defaultMaxWidth = 260; // px.
 const defaultMaxHeight = 342; // px.
 const defaultLoadingSkeletonHeight = 30; // px.
+const defaultLoadingSkeletonHeightWithDescription = 46; // px.
 const totalLoadingRows = 3;
 const defaultLoadingThreshold = 5;
 
@@ -146,8 +147,9 @@ function buildLoadingSkeleton(skeleton?: React.ReactNode): React.ReactNode {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function computeLoadingSkeletonHeight(_loadingSkeleton: any): number {
-  // TODO: access the props of the skeleton to look for certain things that could increase height loadingSkeleton?.props?.hasDescription
+function computeLoadingSkeletonHeight(loadingSkeleton: any): number {
+  if (loadingSkeleton?.props?.hasDescription)
+    return defaultLoadingSkeletonHeightWithDescription;
   return defaultLoadingSkeletonHeight;
 }
 

--- a/src/components/dropdown/dropdownItem.tsx
+++ b/src/components/dropdown/dropdownItem.tsx
@@ -25,6 +25,8 @@ export interface DropdownItemProps {
   children: React.ReactNode;
   /** Type of the dropdown item. Default is simple. */
   type?: DropdownTypes;
+  /** Optional description to render for the item. This will be rendered on a second line. */
+  description?: string;
   /** Height of the content, this is only used for the dropdowns internal logic. This will be auto-calculated if not specified. */
   height?: number;
   /** Whether the dropdown item is selected. */
@@ -50,15 +52,21 @@ const StyledDropdownItemWrapperDiv = styled.div`
   }
 `;
 
-interface StyledDropdownItemContentWrapperDivProps {
+const StyledDropdownItemContentWrapperDiv = styled.div`
+  display: flex;
+  flex-flow: column;
+  font-family: ${fonts.system};
+  grid-area: content;
+  cursor: default;
+  overflow: hidden;
+`;
+
+interface StyledDropdownItemTitleDivProps {
   $isSelected?: boolean;
 }
 
-const StyledDropdownItemContentWrapperDiv = styled.div<StyledDropdownItemContentWrapperDivProps>`
-  font-family: ${fonts.system};
-  grid-area: content;
+const StyledDropdownItemTitleDiv = styled.div<StyledDropdownItemTitleDivProps>`
   color: ${greys.shade80};
-  cursor: default;
   line-height: 16px;
   font-size: ${fontSizes.medium};
   ${ellipsis()};
@@ -76,12 +84,19 @@ const StyledDropdownItemRightContentDiv = styled.div`
   }
 `;
 
+const StyledDropdownItemDescriptionDiv = styled.div`
+  color: ${greys.shade70};
+  line-height: 16px;
+  font-size: ${fontSizes.verySmall};
+  ${ellipsis()};
+`;
+
 /*
  * Component.
  */
 
 export const DropdownItem: FC<DropdownItemProps> = props => {
-  const {children, type = 'simple', isSelected, onClick} = props;
+  const {children, type = 'simple', isSelected, description, onClick} = props;
 
   return (
     <StyledDropdownItemWrapperDiv
@@ -96,8 +111,11 @@ export const DropdownItem: FC<DropdownItemProps> = props => {
       {/* Render non-content items. Avatar, icons, etc. */}
       {renderChildrenSpecifiedComponents(children, nonDropdownContentComponents)}
       {/* Render content items. */}
-      <StyledDropdownItemContentWrapperDiv $isSelected={isSelected}>
-        {renderChildrenIgnoreSpecifiedComponents(children, nonDropdownContentComponents)}
+      <StyledDropdownItemContentWrapperDiv>
+        <StyledDropdownItemTitleDiv $isSelected={isSelected}>
+          {renderChildrenIgnoreSpecifiedComponents(children, nonDropdownContentComponents)}
+        </StyledDropdownItemTitleDiv>
+        {maybeRenderDescription(description)}
       </StyledDropdownItemContentWrapperDiv>
       <StyledDropdownItemRightContentDiv>
         {renderSelectedState(type, isSelected)}
@@ -121,4 +139,14 @@ function renderSelectedState(type: DropdownTypes, isSelected?: boolean) {
       return <Icon name="Checkmark" color={palette.blue.shade40} />;
     }
   }
+}
+
+function maybeRenderDescription(description?: string) {
+  if (!description)
+    return null;
+  return (
+    <StyledDropdownItemDescriptionDiv>
+      {description}
+    </StyledDropdownItemDescriptionDiv>
+  );
 }

--- a/src/components/dropdown/dropdownItemAvatar.tsx
+++ b/src/components/dropdown/dropdownItemAvatar.tsx
@@ -20,6 +20,6 @@ const StyledDropdownAvatarWrapperDiv = styled.div`
 
 export const DropdownItemAvatar: FC<AvatarProps> = props => (
   <StyledDropdownAvatarWrapperDiv>
-    <Avatar {...props} size={props.size || VisualSizesEnum.SMALL} />
+    <Avatar {...props} size={props.size || VisualSizesEnum.MEDIUM} />
   </StyledDropdownAvatarWrapperDiv>
 );

--- a/src/components/dropdown/hooks/useDropdownList.tsx
+++ b/src/components/dropdown/hooks/useDropdownList.tsx
@@ -12,6 +12,7 @@ import {DropdownItem, DropdownItemProps} from '../dropdownItem';
  */
 
 const defaultDropdownItemHeight = 30;
+const defaultDropdownItemHeightWithDescription = 46;
 
 /*
  * Interfaces.
@@ -43,8 +44,16 @@ export function useDropdownList(children: React.ReactNode) {
     const item = items[index];
 
     // If the item is of type "DropdownItem" it could have a custom height specified.
-    if (item.type === 'DropdownItem')
-      return item.props.height || defaultDropdownItemHeight;
+    if (item.type === 'DropdownItem') {
+      // Prioritize rendering the height if specified.
+      if (item.props.height)
+        return item.props.height;
+      // If it has a description, pass back the default with description
+      if (item.props.description)
+        return defaultDropdownItemHeightWithDescription;
+      // Catch-all item height.
+      return defaultDropdownItemHeight;
+    }
 
     // All other items can be the default height.
     return defaultDropdownItemHeight;

--- a/src/components/dropdown/skeleton/dropdownItemSkeleton.tsx
+++ b/src/components/dropdown/skeleton/dropdownItemSkeleton.tsx
@@ -1,20 +1,37 @@
 import React, {FC} from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 
+import {VisualSizesEnum} from '../../../helpers/fontHelpers';
+import {makeSizeConstants} from '../../../helpers/styleHelpers';
 import {Skeleton} from '../../skeleton/skeleton';
+
+/*
+ * Constants.
+ */
+
+const avatarSizes = makeSizeConstants(16, 20, 30, 48);
 
 /*
  * Props.
  */
 
-// TODO: Add support for multi-line (description).
 interface DropdownItemSkeletonProps {
+  /** Whether we should render the avatar. */
   hasAvatar?: boolean;
+  /** The size of the avatar to render a skeleton for. Default is MEDIUM. */
+  avatarSize?: VisualSizesEnum;
+  /** Whether the this is a multi-line skeleton. */
+  hasDescription?: boolean;
 }
 
 /*
  * Style.
  */
+
+const StyledDropdownRightContentWrapperDiv = styled.div`
+  display: grid;
+  align-items: center;
+`;
 
 const StyledDropdownItemSkeletonDiv = styled.div`
   display: flex;
@@ -23,13 +40,44 @@ const StyledDropdownItemSkeletonDiv = styled.div`
   padding: 7px 12px;
 `;
 
+const StyledDropdownContentWrapperDiv = styled.div`
+  flex: 1;
+  display: flex;
+  flex-flow: column;
+  gap: 4px;
+`;
+
+interface StyledTitleWrapperDivProps {
+  $hasDescription?: boolean;
+}
+
+const StyledTitleWrapperDiv = styled.div<StyledTitleWrapperDivProps>`
+  ${p => css`
+    max-width: ${p.$hasDescription ? '60%' : 'unset'};
+  `};
+`;
+
 /*
  * Component.
  */
 
-export const DropdownItemSkeleton: FC<DropdownItemSkeletonProps> = ({hasAvatar}) => (
+export const DropdownItemSkeleton: FC<DropdownItemSkeletonProps> = ({hasAvatar, hasDescription, avatarSize = VisualSizesEnum.MEDIUM}) => (
   <StyledDropdownItemSkeletonDiv>
-    {hasAvatar && <Skeleton borderRadius="100px" width={20} height={20} />}
-    <Skeleton borderRadius="4px" />
+    {hasAvatar && (
+      <StyledDropdownRightContentWrapperDiv>
+        <Skeleton
+          borderRadius="100px"
+          width={avatarSizes[avatarSize]}
+          height={avatarSizes[avatarSize]}
+          variant="dark"
+        />
+      </StyledDropdownRightContentWrapperDiv>
+    )}
+    <StyledDropdownContentWrapperDiv>
+      <StyledTitleWrapperDiv $hasDescription={hasDescription}>
+        <Skeleton borderRadius="4px" variant="dark" />
+      </StyledTitleWrapperDiv>
+      {hasDescription && <Skeleton borderRadius="4px" />}
+    </StyledDropdownContentWrapperDiv>
   </StyledDropdownItemSkeletonDiv>
 );


### PR DESCRIPTION
### Additional Changes

feat: add hasDescription to dropdownItemSkeleton

### Description

This adds in support for passing a `description` to the `DropdownItem` so we can render a second line. This also adds support for the loading skeleton to render with 2 lines.

![2022-05-23 15 10 53](https://user-images.githubusercontent.com/36998210/169906669-b6b238de-01f0-472e-9bc9-660a5e5e33df.gif)
