### PR TITLE
feat: add formField component

### DIFF
--- a/src/components/formField/__docs__/basicInput.stories.tsx
+++ b/src/components/formField/__docs__/basicInput.stories.tsx
@@ -1,0 +1,37 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+import {greys} from '../../../helpers/colorHelpers';
+import {Input} from '../../input/input';
+import {FormField} from '../formField';
+
+export default {
+  title: 'Components/FormField',
+  component: FormField
+} as ComponentMeta<typeof FormField>;
+
+const StyledFormDiv = styled.div`
+  background: ${greys.white};
+  padding: 16px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+`;
+
+const Template: ComponentStory<typeof FormField> = args => {
+  const [value, setValue] = useState('');
+  return (
+    <StyledFormDiv>
+      <FormField {...args}>
+        <Input value={value} onChange={setValue} shouldFocus />
+      </FormField>
+    </StyledFormDiv>
+  );
+};
+
+export const BasicInput = Template.bind({});
+BasicInput.args = {
+  label: "Example form field",
+  hint: "This is an example hint."
+};

--- a/src/components/formField/__docs__/form.stories.tsx
+++ b/src/components/formField/__docs__/form.stories.tsx
@@ -1,0 +1,52 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+import {greys} from '../../../helpers/colorHelpers';
+import {Input} from '../../input/input';
+import {FormField} from '../formField';
+
+// eslint-disable-next-line no-useless-escape
+const emailRegex = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+
+export default {
+  title: 'Components/FormField'
+} as ComponentMeta<typeof FormField>;
+
+const StyledFormDiv = styled.div`
+  background: ${greys.white};
+  padding: 32px 16px 16px 16px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  display: flex;
+  flex-flow: column;
+  gap: 8px;
+`;
+
+const Template: ComponentStory<typeof FormField> = args => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+
+  const isEmailErred = email !== '' && !emailRegex.test(email);
+
+  return (
+    <StyledFormDiv>
+      <FormField label="Your name">
+        <Input value={name} onChange={setName} placeholder="John Smith" />
+      </FormField>
+      <FormField label="Your email" errorMessage={isEmailErred ? 'Please enter a valid email' : undefined}>
+        <Input value={email} type="email" onChange={setEmail} placeholder="john.smith@example.com" />
+      </FormField>
+      <FormField label="Your phone">
+        <Input value={phone} onChange={setPhone} placeholder="1-888-888-8888" />
+      </FormField>
+    </StyledFormDiv>
+  );
+};
+
+export const Form = Template.bind({});
+Form.parameters = {
+  controls: {hideNoControlsWarning: true}
+};

--- a/src/components/formField/formField.tsx
+++ b/src/components/formField/formField.tsx
@@ -1,0 +1,70 @@
+import React, {FC} from 'react';
+import styled, {css} from 'styled-components';
+
+import {greys, palette} from '../../helpers/colorHelpers';
+import {fonts, fontSizes, fontWeights} from '../../helpers/fontHelpers';
+
+/*
+ * Props.
+ */
+
+interface FormFieldProps {
+  /** The label for the form field. */
+  label: string;
+  /** A hint for the form field. If an error message is supplied, this will not be displayed. */
+  hint?: string;
+  /** An error message for the form field. If supplied this will automatically set isErred for the children. */
+  errorMessage?: string;
+  /** Children to render. */
+  children: React.ReactElement;
+}
+
+/*
+ * Style.
+ */
+
+const StyledFormFieldWrapperDiv = styled.div`
+  font-family: ${fonts.system};
+  display: flex;
+  flex-flow: column;
+  gap: 6px;
+`;
+
+const StyledFormFieldLabelDiv = styled.div`
+  font-weight: ${fontWeights.semibold};
+  font-size: ${fontSizes.small};
+  color: ${greys.shade70};
+`;
+
+interface StyledFormFieldHelperTextDivProps {
+  $isErred: boolean;
+}
+
+const StyledFormFieldHelperTextDiv = styled.div<StyledFormFieldHelperTextDivProps>`
+  height: 14px;
+  line-height: 14px;
+
+  ${p => css`
+    font-size: ${fontSizes.verySmall};
+    color: ${p.$isErred ? palette.red.shade40 : greys.shade60};
+    font-weight: ${p.$isErred ? fontWeights.medium : fontWeights.normal};
+  `}
+`;
+
+/*
+ * Component.
+ */
+
+export const FormField: FC<FormFieldProps> = props => {
+  const {label, children, errorMessage, hint} = props;
+  const isErred = Boolean(errorMessage);
+
+  return (
+    <StyledFormFieldWrapperDiv>
+      <StyledFormFieldLabelDiv>{label}</StyledFormFieldLabelDiv>
+      {React.cloneElement(children, {isErred})}
+      <StyledFormFieldHelperTextDiv $isErred={isErred}>{errorMessage || hint}</StyledFormFieldHelperTextDiv>
+    </StyledFormFieldWrapperDiv>
+  );
+};
+


### PR DESCRIPTION
### Components

`<FormField />`

### Description

This adds in support for the form field component. It is a pretty simple component that just wraps the Input field but supports a title/hint/error.

If an errorMessage is supplied it will render instead of the hint and also set `isErred` to the children (whether it supports it or not).

<img width="556" alt="Screen Shot 2022-05-24 at 11 47 22 AM" src="https://user-images.githubusercontent.com/36998210/170106785-bb1d1f5d-7f2d-4bfc-b2ad-188e1f467474.png">

![2022-05-24 12 18 22](https://user-images.githubusercontent.com/36998210/170106788-13d802c3-57de-44e1-91c0-932c1b8ccf21.gif)
