### PR TITLE
feat: add PluginLayout component

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./misc": "./dist/misc/index.js"
+  },
   "scripts": {
     "build": "yarn build:dev",
     "build:watch": "yarn build:dev --watch",

--- a/src/components/popover/reposition.tsx
+++ b/src/components/popover/reposition.tsx
@@ -2,6 +2,7 @@ import {Placement} from '@popperjs/core';
 import maxSize from 'popper-max-size-modifier';
 import React, {FC, useState} from 'react';
 import {Modifier, usePopper} from 'react-popper';
+import styled, {css} from 'styled-components';
 
 import {usePopoverContext} from './popoverContext';
 
@@ -13,6 +14,37 @@ export interface RepositionProps {
   /** Position of the element relative to the anchor. */
   placement?: Placement;
   children?: React.ReactNode;
+}
+
+/*
+ * Styles.
+ */
+
+interface StyledPlacementCoordinatorDivProps {
+  $placement?: Placement;
+}
+
+const StyledPlacementCoordinatorDiv = styled.div<StyledPlacementCoordinatorDivProps>`
+  ${p => addPlacementStyles(p.$placement)};
+`;
+
+function addPlacementStyles(placement?: Placement) {
+  if (!placement)
+    return '';
+
+  // If we have any left or top-end or bottom-end placements we need to change
+  // how the content is rendered since we use max-sizing, this can cause it to be rendered
+  // off screen.
+  if (
+    placement.includes('left') ||
+    placement === 'top-end' ||
+    placement === 'bottom-end'
+  )
+    return css`
+      display: flex;
+      flex-flow: row-reverse;
+    `;
+  return '';
 }
 
 /*
@@ -86,7 +118,13 @@ export const Reposition: FC<RepositionProps> = props => {
     ]
   });
 
-  // Enable prop spreading here as it comes from the popper docs.
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  return <div ref={setPopperElement} style={styles.popper} {...attributes.popper}>{children}</div>;
+  return (
+    // Enable prop spreading here as it comes from the popper docs.
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <div ref={setPopperElement} style={styles.popper} {...attributes.popper}>
+      <StyledPlacementCoordinatorDiv $placement={placement}>
+        {children}
+      </StyledPlacementCoordinatorDiv>
+    </div>
+  );
 };

--- a/src/misc/README.md
+++ b/src/misc/README.md
@@ -1,0 +1,10 @@
+### Purpose
+
+The purpose of the `/misc` directory is to have a single path where we can exporting the following type
+of components:
+
+- Plugin Specific Components
+- Pre-built Complex components
+
+These components will have a strict interface to them, that may not fit all use-cases. If you find a component
+that doesn't work exactly as you would like, they should all be built from smaller components in the library.

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,0 +1,3 @@
+export {PluginLayout} from './plugin/layout/pluginLayout';
+export {PluginHeader} from './plugin/layout/pluginHeader';
+export {PluginFooter} from './plugin/layout/pluginFooter';

--- a/src/misc/plugin/layout/__docs__/layout-sub.stories.tsx
+++ b/src/misc/plugin/layout/__docs__/layout-sub.stories.tsx
@@ -1,0 +1,111 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {FC} from 'react';
+import styled from 'styled-components';
+
+import {DropdownItem} from '../../../..';
+import {Button} from '../../../../components/button/button';
+import {Dropdown} from '../../../../components/dropdown/dropdown';
+import {DropdownCoordinator} from '../../../../components/dropdown/dropdownCoordinator';
+import {DropdownItemIcon} from '../../../../components/dropdown/dropdownItemIcon';
+import {Icon} from '../../../../components/icon/icon';
+import {greys, palette} from '../../../../helpers/colorHelpers';
+import {DefaultStyleProvider} from '../../../../utils/defaultStyleProvider';
+import {PluginFooter} from '../pluginFooter';
+import {PluginHeader} from '../pluginHeader';
+import {PluginLayout} from '../pluginLayout';
+
+/*
+ * Component.
+ */
+
+const StyledLayoutWrapperDiv = styled.div`
+  width: 400px;
+  height: 600px;
+  background: ${greys.white};
+`;
+
+const StyledPluginContentDiv = styled.div`
+  padding: 16px;
+  white-space: pre-wrap;
+`;
+
+const ShowcaseComponent: FC = props => (
+  <DefaultStyleProvider>
+    <StyledLayoutWrapperDiv>
+      <PluginLayout>
+        <PluginHeader
+          onBackClick={() => console.log('On back click')}
+          actions={(
+            <DropdownCoordinator
+              placement="bottom-end"
+              renderButton={isDropdownOpen => (
+                <Button type="icon" isActive={isDropdownOpen}>
+                  <Icon name="EllipsisHorizontal" />
+                </Button>
+              )}
+              renderDropdown={() => (
+                <Dropdown maxHeight={70} maxWidth={175}>
+                  <DropdownItem>
+                    <DropdownItemIcon iconName="Checkmark" color={palette.green.shade40} />
+                    Approve Request
+                  </DropdownItem>
+                  <DropdownItem>
+                    <DropdownItemIcon iconName="Close" color={palette.red.shade40} />
+                    Cancel Request
+                  </DropdownItem>
+                </Dropdown>
+              )}
+            />
+          )}
+        >
+          Sub-level Plugin Page
+        </PluginHeader>
+        <StyledPluginContentDiv>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque at mattis lorem, id varius sem. Praesent commodo
+          eu ex sit amet cursus. Sed condimentum tortor urna, ut dapibus odio vehicula a. Quisque nec odio lorem. In hac habitasse
+          platea dictumst. Mauris dictum varius ultrices. Morbi sed lacus auctor, blandit enim ac, dignissim libero. Praesent a
+          massa augue. Sed turpis dui, accumsan sed tristique in, tincidunt nec metus. In nec vehicula est. Maecenas venenatis
+          tincidunt congue. Ut at fermentum urna. Sed vestibulum mattis dapibus.
+          <br /><br />
+          Donec dictum ut odio at auctor. In laoreet nisi id quam pharetra, in porttitor quam finibus. Donec risus eros,
+          fermentum ac metus at, lobortis facilisis nunc. Nulla facilisi. Nam vitae elementum tellus. Integer tristique tincidunt
+          libero non tristique. Nulla porttitor, leo ut sagittis varius, neque metus fermentum ligula, sit amet bibendum tortor
+          dolor et lorem. Maecenas vestibulum tristique efficitur. Integer vel malesuada dui. Morbi et fermentum lectus. Vivamus
+          imperdiet, magna ac convallis tincidunt, ipsum sapien lacinia erat, et sollicitudin felis diam sit amet justo. Donec
+          est magna, porttitor sed rhoncus ac, malesuada mollis erat. Suspendisse potenti. Sed ullamcorper iaculis porta.
+          <br /><br />
+          Duis fringilla, turpis sed suscipit imperdiet, felis libero laoreet sem, a semper eros purus vel sem. Quisque tincidunt
+          ex at est tincidunt, lobortis ullamcorper metus lobortis. Sed hendrerit posuere erat. Donec quis risus ligula. Morbi
+          maximus lacus turpis, ac gravida neque gravida ac. Cras vel sem tortor. Nam sed erat eu mi imperdiet gravida non ut dui.
+          Integer non massa lobortis, ornare risus sit amet, rutrum orci. Suspendisse potenti. Pellentesque pulvinar, metus ut tempor
+          interdum, lacus turpis pharetra magna, quis viverra purus dolor vitae felis. Sed ullamcorper risus ut ante fermentum, non
+          rutrum magna euismod. Quisque id scelerisque erat.
+          <br /><br />
+          Sed gravida ullamcorper nisl. Donec tempus tempus dolor, vel auctor odio gravida iaculis. Ut facilisis sem et sem
+          faucibus, sed ultricies justo tempus. Vestibulum vulputate vestibulum dui ut cursus. Nullam interdum vehicula consequat.
+          Nulla gravida volutpat orci ac rhoncus. Nulla sagittis ante a libero viverra porttitor. Fusce et porttitor sem. Proin
+          odio tellus, ornare eu euismod at, accumsan vel turpis. Curabitur congue, quam sed pretium pharetra, sem erat auctor libero,
+          placerat aliquam enim eros sed lectus. Sed tincidunt magna vitae tortor auctor vestibulum.
+        </StyledPluginContentDiv>
+        <PluginFooter>
+          Plugin Footer
+        </PluginFooter>
+      </PluginLayout>
+    </StyledLayoutWrapperDiv>
+  </DefaultStyleProvider>
+);
+
+/*
+ * Storybook.
+ */
+
+export default {
+  title: 'Misc/Plugin Layout',
+  component: ShowcaseComponent
+} as ComponentMeta<typeof ShowcaseComponent>;
+
+const Template: ComponentStory<typeof ShowcaseComponent> = () => <ShowcaseComponent />;
+export const SubLevel = Template.bind({});
+SubLevel.parameters = {
+  controls: {hideNoControlsWarning: true}
+};

--- a/src/misc/plugin/layout/__docs__/layout.stories.tsx
+++ b/src/misc/plugin/layout/__docs__/layout.stories.tsx
@@ -1,0 +1,89 @@
+import {ComponentMeta, ComponentStory} from '@storybook/react';
+import React, {FC} from 'react';
+import styled from 'styled-components';
+
+import {Button} from '../../../../components/button/button';
+import {Icon} from '../../../../components/icon/icon';
+import {greys} from '../../../../helpers/colorHelpers';
+import {DefaultStyleProvider} from '../../../../utils/defaultStyleProvider';
+import {PluginFooter} from '../pluginFooter';
+import {PluginHeader} from '../pluginHeader';
+import {PluginLayout} from '../pluginLayout';
+
+/*
+ * Component.
+ */
+
+const StyledLayoutWrapperDiv = styled.div`
+  width: 400px;
+  height: 600px;
+  background: ${greys.white};
+`;
+
+const StyledPluginContentDiv = styled.div`
+  padding: 16px;
+  white-space: pre-wrap;
+`;
+
+const ShowcaseComponent: FC = props => (
+  <DefaultStyleProvider>
+    <StyledLayoutWrapperDiv>
+      <PluginLayout>
+        <PluginHeader
+          actions={(
+            <Button type="icon">
+              <Icon name="Search" />
+            </Button>
+          )}
+        >
+          Top-level Plugin Page
+        </PluginHeader>
+        <StyledPluginContentDiv>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque at mattis lorem, id varius sem. Praesent commodo
+          eu ex sit amet cursus. Sed condimentum tortor urna, ut dapibus odio vehicula a. Quisque nec odio lorem. In hac habitasse
+          platea dictumst. Mauris dictum varius ultrices. Morbi sed lacus auctor, blandit enim ac, dignissim libero. Praesent a
+          massa augue. Sed turpis dui, accumsan sed tristique in, tincidunt nec metus. In nec vehicula est. Maecenas venenatis
+          tincidunt congue. Ut at fermentum urna. Sed vestibulum mattis dapibus.
+          <br /><br />
+          Donec dictum ut odio at auctor. In laoreet nisi id quam pharetra, in porttitor quam finibus. Donec risus eros,
+          fermentum ac metus at, lobortis facilisis nunc. Nulla facilisi. Nam vitae elementum tellus. Integer tristique tincidunt
+          libero non tristique. Nulla porttitor, leo ut sagittis varius, neque metus fermentum ligula, sit amet bibendum tortor
+          dolor et lorem. Maecenas vestibulum tristique efficitur. Integer vel malesuada dui. Morbi et fermentum lectus. Vivamus
+          imperdiet, magna ac convallis tincidunt, ipsum sapien lacinia erat, et sollicitudin felis diam sit amet justo. Donec
+          est magna, porttitor sed rhoncus ac, malesuada mollis erat. Suspendisse potenti. Sed ullamcorper iaculis porta.
+          <br /><br />
+          Duis fringilla, turpis sed suscipit imperdiet, felis libero laoreet sem, a semper eros purus vel sem. Quisque tincidunt
+          ex at est tincidunt, lobortis ullamcorper metus lobortis. Sed hendrerit posuere erat. Donec quis risus ligula. Morbi
+          maximus lacus turpis, ac gravida neque gravida ac. Cras vel sem tortor. Nam sed erat eu mi imperdiet gravida non ut dui.
+          Integer non massa lobortis, ornare risus sit amet, rutrum orci. Suspendisse potenti. Pellentesque pulvinar, metus ut tempor
+          interdum, lacus turpis pharetra magna, quis viverra purus dolor vitae felis. Sed ullamcorper risus ut ante fermentum, non
+          rutrum magna euismod. Quisque id scelerisque erat.
+          <br /><br />
+          Sed gravida ullamcorper nisl. Donec tempus tempus dolor, vel auctor odio gravida iaculis. Ut facilisis sem et sem
+          faucibus, sed ultricies justo tempus. Vestibulum vulputate vestibulum dui ut cursus. Nullam interdum vehicula consequat.
+          Nulla gravida volutpat orci ac rhoncus. Nulla sagittis ante a libero viverra porttitor. Fusce et porttitor sem. Proin
+          odio tellus, ornare eu euismod at, accumsan vel turpis. Curabitur congue, quam sed pretium pharetra, sem erat auctor libero,
+          placerat aliquam enim eros sed lectus. Sed tincidunt magna vitae tortor auctor vestibulum.
+        </StyledPluginContentDiv>
+        <PluginFooter>
+          Plugin Footer
+        </PluginFooter>
+      </PluginLayout>
+    </StyledLayoutWrapperDiv>
+  </DefaultStyleProvider>
+);
+
+/*
+ * Storybook.
+ */
+
+export default {
+  title: 'Misc/Plugin Layout',
+  component: ShowcaseComponent
+} as ComponentMeta<typeof ShowcaseComponent>;
+
+const Template: ComponentStory<typeof ShowcaseComponent> = () => <ShowcaseComponent />;
+export const TopLevel = Template.bind({});
+TopLevel.parameters = {
+  controls: {hideNoControlsWarning: true}
+};

--- a/src/misc/plugin/layout/pluginFooter.tsx
+++ b/src/misc/plugin/layout/pluginFooter.tsx
@@ -1,0 +1,30 @@
+import React, {FC} from 'react';
+import styled from 'styled-components';
+
+import {greys} from '../../../helpers/colorHelpers';
+
+/*
+ * Props.
+ */
+
+interface PluginFooterProps {
+  children: React.ReactNode;
+}
+
+/*
+ * Style.
+ */
+
+const StyledFooterWrapperDiv = styled.div`
+  grid-area: plugin-footer;
+  border-top: 1px solid ${greys.shade30};
+  padding: 20px;
+`;
+
+/*
+ * Component.
+ */
+
+export const PluginFooter: FC<PluginFooterProps> = ({children}) => (
+  <StyledFooterWrapperDiv>{children}</StyledFooterWrapperDiv>
+);

--- a/src/misc/plugin/layout/pluginHeader.tsx
+++ b/src/misc/plugin/layout/pluginHeader.tsx
@@ -1,0 +1,112 @@
+import React, {FC, MouseEventHandler} from 'react';
+import styled, {css} from 'styled-components';
+
+import {Button} from '../../../components/button/button';
+import {Icon} from '../../../components/icon/icon';
+import {greys} from '../../../helpers/colorHelpers';
+import {fonts, fontSizes, fontWeights} from '../../../helpers/fontHelpers';
+
+/*
+ * Props.
+ */
+
+interface PluginHeaderProps {
+  /** Content to render for the header. */
+  children: React.ReactNode;
+  /** Actions that will be rendered to the right of the content. */
+  actions?: React.ReactNode;
+  /** Controls if we are on a sub-page. If not passed in we will assume we are at a top level. */
+  onBackClick?: MouseEventHandler;
+}
+
+/*
+ * Style.
+ */
+
+const StyledPluginHeaderWrapperDiv = styled.div`
+  display: flex;
+  flex-flow: row;
+  font-family: ${fonts.system};
+  grid-area: plugin-header;
+  height: 56px;
+  flex-flow: row;
+`;
+
+interface StyledPluginTitleDivProps {
+  $isSubPage: boolean;
+}
+
+const StyledPluginTitleDiv = styled.div<StyledPluginTitleDivProps>`
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  flex: 1;
+  color: ${greys.shade90};
+  font-weight: ${fontWeights.bold};
+  font-size: ${fontSizes.large};
+  padding-left: 16px;
+
+  ${p => p.$isSubPage && css`
+    color: ${greys.shade70};
+    font-weight: ${fontWeights.semibold};
+    font-size: ${fontSizes.medium};
+  `};
+`;
+
+const StyledButtonWrapperDiv = styled.div`
+  margin-right: -8px;
+  padding-left: 8px;
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+`;
+
+const StyledActionsWrapperDiv = styled.div`
+  padding: 0 8px;
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+`;
+
+/*
+ * Component.
+ */
+
+export const PluginHeader: FC<PluginHeaderProps> = props => {
+  const {children, onBackClick, actions} = props;
+  return (
+    <StyledPluginHeaderWrapperDiv>
+      {maybeRenderBackButton(onBackClick)}
+      <StyledPluginTitleDiv $isSubPage={Boolean(onBackClick)}>
+        {children}
+      </StyledPluginTitleDiv>
+      {maybeRenderActions(actions)}
+    </StyledPluginHeaderWrapperDiv>
+  );
+};
+
+/*
+ * Helpers.
+ */
+
+function maybeRenderBackButton(onBackClick?: MouseEventHandler) {
+  if (!onBackClick)
+    return null;
+  return (
+    <StyledButtonWrapperDiv>
+      <Button type="icon" onClick={onBackClick}>
+        <Icon name="ChevronLeft" />
+      </Button>
+    </StyledButtonWrapperDiv>
+  );
+}
+
+function maybeRenderActions(actions?: React.ReactNode) {
+  if (!actions)
+    return null;
+  return (
+    <StyledActionsWrapperDiv>
+      {actions}
+    </StyledActionsWrapperDiv>
+  );
+}

--- a/src/misc/plugin/layout/pluginLayout.tsx
+++ b/src/misc/plugin/layout/pluginLayout.tsx
@@ -1,0 +1,44 @@
+import React, {FC} from 'react';
+import styled from 'styled-components';
+
+import {renderChildrenIgnoreSpecifiedComponents, renderChildrenSpecifiedComponents} from '../../../helpers/renderHelpers';
+
+/*
+ * Props.
+ */
+
+interface PluginLayoutProps {
+  /** Content to render for the plugin. */
+  children: React.ReactNode;
+}
+
+/*
+ * Style.
+ */
+
+const StyledPluginLayoutWrapperDiv = styled.div`
+  height: 100%;
+  display: grid;
+  grid-template-areas: "plugin-header"
+                       "plugin-content"
+                       "plugin-footer";
+  grid-template-rows: auto 1fr auto;
+`;
+
+const StyledPluginContentWrapperDiv = styled.div`
+  grid-area: plugin-content;
+  overflow: auto;
+`;
+
+/*
+ * Component.
+ */
+
+export const PluginLayout: FC<PluginLayoutProps> = ({children}) => (
+  <StyledPluginLayoutWrapperDiv>
+    {renderChildrenSpecifiedComponents(children, ['PluginHeader', 'PluginFooter'])}
+    <StyledPluginContentWrapperDiv>
+      {renderChildrenIgnoreSpecifiedComponents(children, ['PluginHeader', 'PluginFooter'])}
+    </StyledPluginContentWrapperDiv>
+  </StyledPluginLayoutWrapperDiv>
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,10 @@ const path = require('path');
 const isProduction = process.argv.indexOf('--mode=production') !== -1;
 
 module.exports = {
-  entry: './src/index.ts',
+  entry: {
+    index: './src/index.ts',
+    'misc/index': './src/misc/index.ts'
+  },
   devtool: !isProduction ? 'inline-source-map' : undefined,
   externals: {
     react: 'react',
@@ -85,7 +88,7 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js']
   },
   output: {
-    filename: 'index.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
     clean: true,
     library: {


### PR DESCRIPTION
## Additional changes

feat: add PluginHeader component
feat: add PluginFooter component
fix: issue with end placements for dropdowns
build: allow building a misc directory

## Description

This adds in the support for the layout components of a plugin which is exposed in the `/misc` directory. This directory is now built with a separate index file.

There was some issue with having placement on the `left` and `*-end` but that is now resolved since we use max with computations.

![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/36998210/170559733-ce576f11-fdaa-44c5-8848-1c08b42a36fa.gif)

