### PR TITLE
feat: add isRequired to FormField

### DIFF
--- a/src/components/formField/formField.tsx
+++ b/src/components/formField/formField.tsx
@@ -1,3 +1,4 @@
+import {ellipsis} from 'polished';
 import React, {FC} from 'react';
 import styled, {css} from 'styled-components';
 
@@ -15,6 +16,8 @@ interface FormFieldProps {
   hint?: string;
   /** An error message for the form field. If supplied this will automatically set isErred for the children. */
   errorMessage?: string;
+  /** Whether we should show the "*". */
+  isRequired?: boolean;
   /** Children to render. */
   children: React.ReactElement;
 }
@@ -31,9 +34,20 @@ const StyledFormFieldWrapperDiv = styled.div`
 `;
 
 const StyledFormFieldLabelDiv = styled.div`
+  display: flex;
+  flex-flow: row;
   font-weight: ${fontWeights.semibold};
   font-size: ${fontSizes.small};
   color: ${greys.shade70};
+`;
+
+const StyledLabelWrapperDiv = styled.div`
+  ${ellipsis()};
+`;
+
+const StyledRequiredTagDiv = styled.div`
+  color: ${palette.red.shade40};
+  margin-left: 4px;
 `;
 
 interface StyledFormFieldHelperTextDivProps {
@@ -56,12 +70,15 @@ const StyledFormFieldHelperTextDiv = styled.div<StyledFormFieldHelperTextDivProp
  */
 
 export const FormField: FC<FormFieldProps> = props => {
-  const {label, children, errorMessage, hint} = props;
+  const {label, children, errorMessage, hint, isRequired} = props;
   const isErred = Boolean(errorMessage);
 
   return (
     <StyledFormFieldWrapperDiv>
-      <StyledFormFieldLabelDiv>{label}</StyledFormFieldLabelDiv>
+      <StyledFormFieldLabelDiv>
+        <StyledLabelWrapperDiv>{label}</StyledLabelWrapperDiv>
+        {isRequired && <StyledRequiredTagDiv>*</StyledRequiredTagDiv>}
+      </StyledFormFieldLabelDiv>
       {React.cloneElement(children, {isErred})}
       <StyledFormFieldHelperTextDiv $isErred={isErred}>{errorMessage || hint}</StyledFormFieldHelperTextDiv>
     </StyledFormFieldWrapperDiv>


### PR DESCRIPTION
### Description

Missed adding this to the FormField. This adds the `*` when the form field is required.

<img width="554" alt="Screen Shot 2022-05-26 at 1 22 04 PM" src="https://user-images.githubusercontent.com/36998210/170561840-9d658fcd-7bce-42bc-bea1-19448d87cb82.png">
<img width="555" alt="Screen Shot 2022-05-26 at 1 22 12 PM" src="https://user-images.githubusercontent.com/36998210/170561842-ff514268-574c-42a8-a10a-4faaff1d8102.png">
