### PR TITLE
fix: horizontally center align checkbox and label

### DIFF
--- a/src/components/checkbox/__tests__/__snapshots__/checkbox.spec.tsx.snap
+++ b/src/components/checkbox/__tests__/__snapshots__/checkbox.spec.tsx.snap
@@ -9,6 +9,10 @@ exports[`<Checkbox /> Spec Snapshots should render a checkbox with a label 1`] =
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -86,6 +90,10 @@ exports[`<Checkbox /> Spec Snapshots should render a checked and disabled checkb
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -175,6 +183,10 @@ exports[`<Checkbox /> Spec Snapshots should render a checked checkbox 1`] = `
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -258,6 +270,10 @@ exports[`<Checkbox /> Spec Snapshots should render an empty and disabled checkbo
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -330,6 +346,10 @@ exports[`<Checkbox /> Spec Snapshots should render an empty checkbox 1`] = `
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -405,6 +425,10 @@ exports[`<Checkbox /> Spec Snapshots should render an indeterminate and disabled
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -494,6 +518,10 @@ exports[`<Checkbox /> Spec Snapshots should render an indeterminate checkbox 1`]
   -webkit-flex-flow: row;
   -ms-flex-flow: row;
   flex-flow: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -35,6 +35,7 @@ interface StyledCheckboxInputProps {
 const StyledWrapperDiv = styled.div`
   display: flex;
   flex-flow: row;
+  align-items: center;
 `;
 
 const StyledCheckboxDiv = styled.div`


### PR DESCRIPTION
### Before

<img width="352" alt="Screen Shot 2022-05-27 at 4 08 43 PM" src="https://user-images.githubusercontent.com/7339937/170799330-b61b048d-93f8-44fb-b00d-5936e6e2cab1.png">

### After
<img width="368" alt="Screen Shot 2022-05-27 at 4 20 55 PM" src="https://user-images.githubusercontent.com/7339937/170799658-fd43e87f-adc4-47e9-8658-9e027fcd0ad8.png">


