### PR TITLE
chore: relax dependabot watchlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
Configure dependabot to only keep production dependencies up to date.