### PR TITLE
fix: export select and formfield

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "files": [
     "dist"
   ],
-  "exports": {
-    ".": "./dist/index.js",
-    "./elements": "./dist/elements/index.js",
-    "./layout": "./dist/layout/index.js",
-    "./text": "./dist/text/index.js"
-  },
+  "exports": "./dist/index.js",
   "scripts": {
     "build": "yarn build:dev",
     "build:watch": "yarn build:dev --watch",

--- a/src/elements/dropdown/__docs__/docs.mdx
+++ b/src/elements/dropdown/__docs__/docs.mdx
@@ -22,7 +22,7 @@ import { ButtonGroup } from '../../../components/button/buttonGroup';
 </Canvas>
 
 ```typescript
-import {Dropdown} from '@frontapp/ui-kit/elements';
+import {Dropdown} from '@frontapp/ui-kit';
 ```
 
 The dropdown components listed here enables you to easily build out custom dropdowns with many
@@ -50,7 +50,7 @@ so it should stay performant when you have 5 items to 5,000 items.
 # Dropdown Coordinator
 
 ```typescript
-import {DropdownCoordinator} from '@frontapp/ui-kit/elements';
+import {DropdownCoordinator} from '@frontapp/ui-kit';
 ```
 
 The `DropdownCoordinator` is the master component that controls how the render the dropdown, the button
@@ -73,7 +73,7 @@ that will open the dropdown, etc.
 </Canvas>
 
 ```typescript
-import {DropdownButton} from '@frontapp/ui-kit/elements';
+import {DropdownButton} from '@frontapp/ui-kit';
 ```
 
 The `DropdownButton` is a simple, opinionated component for rendering a button that is specific to `Dropdown`s.
@@ -102,7 +102,7 @@ the preferred button.
 </Canvas>
 
 ```typescript
-import {DropdownHeader} from '@frontapp/ui-kit/elements';
+import {DropdownHeader} from '@frontapp/ui-kit';
 ```
 
 The `DropdownHeader` will render in the `header` grid area of the `Dropdown` component. 
@@ -136,7 +136,7 @@ If the `onBackClick` is not supplied, we will not render the back button in the 
 </Canvas>
 
 ```typescript
-import {DropdownFooter} from '@frontapp/ui-kit/elements';
+import {DropdownFooter} from '@frontapp/ui-kit';
 ```
 
 The `DropdownFooter` is a simple component that you would use in the `Dropdown` component to render things in the
@@ -161,7 +161,7 @@ The `DropdownFooter` is a simple component that you would use in the `Dropdown` 
 </Canvas>
 
 ```typescript
-import {DropdownHeading} from '@frontapp/ui-kit/elements';
+import {DropdownHeading} from '@frontapp/ui-kit';
 ```
 
 The `DropdownHeading` is used to separate areas of the dropdown.
@@ -186,7 +186,7 @@ The `DropdownHeading` is used to separate areas of the dropdown.
 </Canvas>
 
 ```typescript
-import {DropdownItem} from '@frontapp/ui-kit/elements';
+import {DropdownItem} from '@frontapp/ui-kit';
 ```
 
 The `DropdownItem` is the main item for rendering items in the `Dropdown` component.
@@ -202,7 +202,7 @@ The `DropdownItem` is the main item for rendering items in the `Dropdown` compon
 # Dropdown Item Avatar
 
 ```typescript
-import {DropdownItemAvatar} from '@frontapp/ui-kit/elements';
+import {DropdownItemAvatar} from '@frontapp/ui-kit';
 ```
 
 The `DropdownItemAvatar` allows easily adding an avatar to the left side of a `DropdownItem`.
@@ -219,7 +219,7 @@ The `DropdownItemAvatar` allows easily adding an avatar to the left side of a `D
 # Dropdown Item Icon
 
 ```typescript
-import {DropdownItemIcon} from '@frontapp/ui-kit/elements';
+import {DropdownItemIcon} from '@frontapp/ui-kit';
 ```
 
 The `DropdownItemIcon` allows easily adding an icon to the right or left of the dropdown item.
@@ -237,7 +237,7 @@ The `DropdownItemIcon` allows easily adding an icon to the right or left of the 
 # Dropdown Form Field
 
 ```typescript
-import {DropdownFormField} from '@frontapp/ui-kit/elements';
+import {DropdownFormField} from '@frontapp/ui-kit';
 ```
 
 Sometimes you may need input from the user in a Dropdown such as a simple create form.
@@ -269,7 +269,7 @@ enables rendering in a dropdown.
 </Canvas>
 
 ```typescript
-import {DropdownItemSpacer} from '@frontapp/ui-kit/elements';
+import {DropdownItemSpacer} from '@frontapp/ui-kit';
 ```
 
 The `DropdownItemSpacer` is a simple component to break up a long list of dropdown items.

--- a/src/elements/emptyState/__docs__/docs.mdx
+++ b/src/elements/emptyState/__docs__/docs.mdx
@@ -10,7 +10,7 @@ import { EmptyState } from '../emptyState';
 </Canvas>
 
 ```typescript
-import {EmptyState} from '@frontapp/ui-kit/elements';
+import {EmptyState} from '@frontapp/ui-kit';
 ```
 
 An empty state is typically used in Dropdowns when there are no elements which match the search.

--- a/src/elements/icon/__docs__/docs.mdx
+++ b/src/elements/icon/__docs__/docs.mdx
@@ -6,7 +6,7 @@ import { Icon as IconExample } from '../icon';
 # Icon
 
 ```typescript
-import {Icon} from '@frontapp/ui-kit/elements';
+import {Icon} from '@frontapp/ui-kit';
 ```
 
 ## Generic Icons

--- a/src/elements/input/__docs__/docs.mdx
+++ b/src/elements/input/__docs__/docs.mdx
@@ -10,7 +10,7 @@ import { Input } from '../input';
 </Canvas>
 
 ```typescript
-import {Input} from '@frontapp/ui-kit/elements';
+import {Input} from '@frontapp/ui-kit';
 ```
 
 The input component is a simple component that wraps the standard `input` element.

--- a/src/elements/textarea/__docs__/docs.mdx
+++ b/src/elements/textarea/__docs__/docs.mdx
@@ -10,7 +10,7 @@ import { Textarea } from '../textarea';
 </Canvas>
 
 ```typescript
-import {Textarea} from '@frontapp/ui-kit/elements';
+import {Textarea} from '@frontapp/ui-kit';
 ```
 
 The `Textarea` is used when you want to allow multiple lines of text input from the user.

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,11 @@ export {Task} from './components/_pre-built/task/task';
 
 export {Tooltip} from './components/tooltip/tooltip';
 export {TooltipCoordinator} from './components/tooltip/tooltipCoordinator';
+
+/*
+ * Additional Exports.
+ */
+
+export * from './elements/index';
+export * from './layout/index';
+export * from './text/index';

--- a/src/layout/plugin/layout/__docs__/docs.mdx
+++ b/src/layout/plugin/layout/__docs__/docs.mdx
@@ -12,7 +12,7 @@ import { PluginFooter } from '../pluginFooter';
 </Canvas>
 
 ```typescript
-import {PluginLayout} from '@frontapp/ui-kit/layout';
+import {PluginLayout} from '@frontapp/ui-kit';
 ```
 
 The `PluginLayout` is a simple layout component that enables a standard layout that most
@@ -29,7 +29,7 @@ plugins will want to follow.
 # Plugin Header
 
 ```typescript
-import {PluginHeader} from '@frontapp/ui-kit/layout';
+import {PluginHeader} from '@frontapp/ui-kit';
 ```
 
 The `PluginHeader` will render the content supplied in the `header` grid-area of the `PluginLayout`.
@@ -45,7 +45,7 @@ The `PluginHeader` will render the content supplied in the `header` grid-area of
 # Plugin Footer
 
 ```typescript
-import {PluginFooter} from '@frontapp/ui-kit/layout';
+import {PluginFooter} from '@frontapp/ui-kit';
 ```
 
 The `PluginFooter` will render the content supplied in the `footer` grid-area of the `PluginLayout`.

--- a/src/text/heading/__docs__/docs.mdx
+++ b/src/text/heading/__docs__/docs.mdx
@@ -10,7 +10,7 @@ import { Heading } from '../heading';
 </Canvas>
 
 ```typescript
-import {Heading} from '@frontapp/ui-kit/text';
+import {Heading} from '@frontapp/ui-kit';
 ```
 
 The `Heading` component is a simple component that you can wrap around any text to style it in

--- a/src/text/paragraph/__docs__/docs.mdx
+++ b/src/text/paragraph/__docs__/docs.mdx
@@ -10,7 +10,7 @@ import { Paragraph } from '../paragraph';
 </Canvas>
 
 ```typescript
-import {Paragraph} from '@frontapp/ui-kit/text';
+import {Paragraph} from '@frontapp/ui-kit';
 ```
 
 The `Paragraph` component is a simple component that you can wrap around any text to style it in

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,10 +4,7 @@ const isProduction = process.argv.indexOf('--mode=production') !== -1;
 
 module.exports = {
   entry: {
-    index: './src/index.ts',
-    'elements/index': './src/elements/index.ts',
-    'layout/index': './src/layout/index.ts',
-    'text/index': './src/text/index.ts'
+    index: './src/index.ts'
   },
   devtool: !isProduction ? 'inline-source-map' : undefined,
   externals: {


### PR DESCRIPTION
fix!: move all components to export from base

### Description

These components were not exported. Must have been missed when I moved things around. This also moves everything to be exported from the base index file instead of separate ones as it seems that doesn't work as we would expect all the time.