### PR TITLE
feat: better icon showcase in docs

### DIFF
--- a/src/elements/icon/__docs__/docs.mdx
+++ b/src/elements/icon/__docs__/docs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Title, IconGallery, IconItem } from '@storybook/addon-docs/';
+import { Meta, Title, Story } from '@storybook/addon-docs';
 import { Icon as IconExample } from '../icon';
 
 <Meta title="Elements/Icon" />
@@ -9,162 +9,12 @@ import { Icon as IconExample } from '../icon';
 import {Icon} from '@frontapp/ui-kit';
 ```
 
+You can click on the icon to copy the IconName for easy usage.
+
 ## Generic Icons
 
-<IconGallery>
-  <IconItem name="Archive">
-    <IconExample name="Archive" />
-  </IconItem>
-  <IconItem name="ArchiveFilled">
-    <IconExample name="ArchiveFilled" />
-  </IconItem>
-  <IconItem name="Assign">
-    <IconExample name="Assign" />
-  </IconItem>
-  <IconItem name="AssignFilled">
-    <IconExample name="AssignFilled" />
-  </IconItem>
-  <IconItem name="Calendar">
-    <IconExample name="Calendar" />
-  </IconItem>
-  <IconItem name="CalendarFilled">
-    <IconExample name="CalendarFilled" />
-  </IconItem>
-  <IconItem name="CheckmarkBox">
-    <IconExample name="CheckmarkBox" />
-  </IconItem>
-  <IconItem name="CheckmarkCircle">
-    <IconExample name="CheckmarkCircle" />
-  </IconItem>
-  <IconItem name="CheckmarkCircleEmpty">
-    <IconExample name="CheckmarkCircleEmpty" />
-  </IconItem>
-  <IconItem name="Checkmark">
-    <IconExample name="Checkmark" />
-  </IconItem>
-  <IconItem name="ChevronDown">
-    <IconExample name="ChevronDown" />
-  </IconItem>
-  <IconItem name="ChevronLeft">
-    <IconExample name="ChevronLeft" />
-  </IconItem>
-  <IconItem name="ChevronRight">
-    <IconExample name="ChevronRight" />
-  </IconItem>
-  <IconItem name="ChevronUp">
-    <IconExample name="ChevronUp" />
-  </IconItem>
-  <IconItem name="Close">
-    <IconExample name="Close" />
-  </IconItem>
-  <IconItem name="Copy">
-    <IconExample name="Copy" />
-  </IconItem>
-  <IconItem name="Edit">
-    <IconExample name="Edit" />
-  </IconItem>
-  <IconItem name="EditFilled">
-    <IconExample name="EditFilled" />
-  </IconItem>
-  <IconItem name="Export">
-    <IconExample name="Export" />
-  </IconItem>
-  <IconItem name="ExternalLink">
-    <IconExample name="ExternalLink" />
-  </IconItem>
-  <IconItem name="Gear">
-    <IconExample name="Gear" />
-  </IconItem>
-  <IconItem name="GearFilled">
-    <IconExample name="GearFilled" />
-  </IconItem>
-  <IconItem name="Import">
-    <IconExample name="Import" />
-  </IconItem>
-  <IconItem name="Info">
-    <IconExample name="Info" />
-  </IconItem>
-  <IconItem name="InfoFilled">
-    <IconExample name="InfoFilled" />
-  </IconItem>
-  <IconItem name="Minus">
-    <IconExample name="Minus" />
-  </IconItem>
-  <IconItem name="EllipsisHorizontal">
-    <IconExample name="EllipsisHorizontal" />
-  </IconItem>
-  <IconItem name="EllipsisVertical">
-    <IconExample name="EllipsisVertical" />
-  </IconItem>
-  <IconItem name="Plus">
-    <IconExample name="Plus" />
-  </IconItem>
-  <IconItem name="NewContact">
-    <IconExample name="NewContact" />
-  </IconItem>
-  <IconItem name="Participant">
-    <IconExample name="Participant" />
-  </IconItem>
-  <IconItem name="ParticipantFilled">
-    <IconExample name="ParticipantFilled" />
-  </IconItem>
-  <IconItem name="PlusCircle">
-    <IconExample name="PlusCircle" />
-  </IconItem>
-  <IconItem name="Preferences">
-    <IconExample name="Preferences" />
-  </IconItem>
-  <IconItem name="Search">
-    <IconExample name="Search" />
-  </IconItem>
-  <IconItem name="Star">
-    <IconExample name="Star" />
-  </IconItem>
-  <IconItem name="StarFilled">
-    <IconExample name="StarFilled" />
-  </IconItem>
-  <IconItem name="Trash">
-    <IconExample name="Trash" />
-  </IconItem>
-  <IconItem name="TrashFilled">
-    <IconExample name="TrashFilled" />
-  </IconItem>
-</IconGallery>
+<Story id="elements-icon--basic-icons" />
 
 ## Attachment Icons
 
-<IconGallery>
-  <IconItem name="AttachmentArchive">
-    <IconExample name="AttachmentArchive" />
-  </IconItem>
-  <IconItem name="AttachmentCalendar">
-    <IconExample name="AttachmentCalendar" />
-  </IconItem>
-  <IconItem name="AttachmentCode">
-    <IconExample name="AttachmentCode" />
-  </IconItem>
-  <IconItem name="AttachmentExcel">
-    <IconExample name="AttachmentExcel" />
-  </IconItem>
-  <IconItem name="AttachmentGeneric">
-    <IconExample name="AttachmentGeneric" />
-  </IconItem>
-  <IconItem name="AttachmentImage">
-    <IconExample name="AttachmentImage" />
-  </IconItem>
-  <IconItem name="AttachmentMusic">
-    <IconExample name="AttachmentMusic" />
-  </IconItem>
-  <IconItem name="AttachmentPdf">
-    <IconExample name="AttachmentPdf" />
-  </IconItem>
-  <IconItem name="AttachmentPowerpoint">
-    <IconExample name="AttachmentPowerpoint" />
-  </IconItem>
-  <IconItem name="AttachmentVideo">
-    <IconExample name="AttachmentVideo" />
-  </IconItem>
-  <IconItem name="AttachmentWord">
-    <IconExample name="AttachmentWord" />
-  </IconItem>
-</IconGallery>
+<Story id="elements-icon--attachment-icons" />

--- a/src/elements/icon/__docs__/index.stories.tsx
+++ b/src/elements/icon/__docs__/index.stories.tsx
@@ -26,3 +26,5 @@ export default {
 } as ComponentMeta<typeof Icon>;
 
 export {Basic} from './stories/basic.stories';
+export {BasicIcons} from './stories/basic-icon-showcase.stories';
+export {AttachmentIcons} from './stories/attachment-icon-showcase.stories';

--- a/src/elements/icon/__docs__/stories/attachment-icon-showcase.stories.tsx
+++ b/src/elements/icon/__docs__/stories/attachment-icon-showcase.stories.tsx
@@ -1,0 +1,11 @@
+import {ComponentStory} from '@storybook/react';
+import React from 'react';
+
+import {Icon, icons} from '../../icon';
+import {IconShowcase} from './showcase.stories';
+
+const Template: ComponentStory<typeof Icon> = () => (
+  <IconShowcase iconNames={Object.keys(icons).filter(iconName => iconName.includes('Attachment'))} />
+);
+
+export const AttachmentIcons = Template.bind({});

--- a/src/elements/icon/__docs__/stories/basic-icon-showcase.stories.tsx
+++ b/src/elements/icon/__docs__/stories/basic-icon-showcase.stories.tsx
@@ -1,0 +1,11 @@
+import {ComponentStory} from '@storybook/react';
+import React from 'react';
+
+import {Icon, icons} from '../../icon';
+import {IconShowcase} from './showcase.stories';
+
+const Template: ComponentStory<typeof Icon> = () => (
+  <IconShowcase iconNames={Object.keys(icons).filter(iconName => !iconName.includes('Attachment'))} />
+);
+
+export const BasicIcons = Template.bind({});

--- a/src/elements/icon/__docs__/stories/showcase.stories.tsx
+++ b/src/elements/icon/__docs__/stories/showcase.stories.tsx
@@ -1,0 +1,125 @@
+import React, {FC, useState} from 'react';
+import styled from 'styled-components';
+
+import {Tooltip} from '../../../../components/tooltip/tooltip';
+import {TooltipCoordinator} from '../../../../components/tooltip/tooltipCoordinator';
+import {greys, palette} from '../../../../helpers/colorHelpers';
+import {fontSizes} from '../../../../helpers/fontHelpers';
+import {DefaultStyleProvider} from '../../../../utils/defaultStyleProvider';
+import {Icon, IconName} from '../../icon';
+/*
+ * Props.
+ */
+
+interface IconShowcaseProps {
+  iconNames: ReadonlyArray<string>;
+}
+
+/*
+ * Style.
+ */
+
+const StyledIconsContainerDiv = styled.div`
+  margin: auto;
+  width: 100%;
+  display: flex;
+  flex-flow: row;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const StyledIconWrapperDiv = styled.div`
+  flex: 0 0 10%;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  padding: 8px 0;
+  overflow: hidden;
+`;
+
+const StyledIconDiv = styled.div`
+  width: 32px;
+  padding: 4px;
+  cursor: pointer;
+  &:hover {
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 8px;
+  }
+`;
+
+const StyledCopiedDiv = styled.div`
+  width: 32px;
+  height: 34px;
+  padding: 2px 4px 4px 4px;
+  background: ${palette.green.shade40};
+  border-radius: 8px;
+  align-items: center;
+  display: flex;
+  flex-flow: column;
+`;
+
+const StyledIconNameDiv = styled.div`
+  text-align: center;
+  font-size: ${fontSizes.veryTiny};
+  color: ${greys.shade70};
+  margin-top: 8px;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const StyledCopiedTextDiv = styled.div`
+  color: white;
+  font-size: 8px;
+`;
+
+/*
+ * Component.
+ */
+
+export const IconShowcase: FC<IconShowcaseProps> = props => {
+  const {iconNames} = props;
+  const [copiedIconName, setCopiedIconName] = useState<string | undefined>();
+
+  const onIconCopied = (name?: string) => {
+    if (!name) {
+      setCopiedIconName(undefined);
+      return;
+    }
+    navigator.clipboard.writeText(name);
+    setCopiedIconName(name);
+  };
+
+  return (
+    <DefaultStyleProvider>
+      <StyledIconsContainerDiv>
+        {iconNames.map(iconName => {
+          if (copiedIconName && copiedIconName === iconName)
+            return (
+              <StyledIconWrapperDiv key={iconName}>
+                <StyledCopiedDiv onMouseLeave={() => onIconCopied(undefined)}>
+                  <Icon name="Checkmark" size={22} color={greys.white} />
+                  <StyledCopiedTextDiv>Copied</StyledCopiedTextDiv>
+                </StyledCopiedDiv>
+                <StyledIconNameDiv>{iconName}</StyledIconNameDiv>
+              </StyledIconWrapperDiv>
+            );
+          return (
+            <StyledIconWrapperDiv key={iconName}>
+              <StyledIconDiv onClick={() => onIconCopied(iconName)}>
+                <Icon name={iconName as IconName} size={32} />
+              </StyledIconDiv>
+              <StyledIconNameDiv>
+                <TooltipCoordinator
+                  condition={{type: 'overflow'}}
+                  renderTooltip={() => <Tooltip>{iconName}</Tooltip>}
+                >
+                  {iconName}
+                </TooltipCoordinator>
+              </StyledIconNameDiv>
+            </StyledIconWrapperDiv>
+          );
+        })}
+      </StyledIconsContainerDiv>
+    </DefaultStyleProvider>
+  );
+};


### PR DESCRIPTION
### Description

The current icon gallery is not super useful and also has overflow issues. This brings back the previous way of doing things.

<img width="257" alt="Screen Shot 2022-07-14 at 2 19 34 PM" src="https://user-images.githubusercontent.com/36998210/179076221-454d9a05-7df3-4d75-beac-5af6a1751368.png">
<img width="1008" alt="Screen Shot 2022-07-14 at 2 19 20 PM" src="https://user-images.githubusercontent.com/36998210/179076225-069ed56d-2b5c-42ca-848e-ce3b61a12628.png">
