### PR TITLE
fix: dropdown usage of min width param

### DIFF
--- a/src/elements/dropdown/dropdown.tsx
+++ b/src/elements/dropdown/dropdown.tsx
@@ -122,6 +122,7 @@ export const Dropdown: FC<DropdownProps> = ({
   maxWidth = defaultMaxWidth,
   maxHeight = defaultMaxHeight,
   // The minHeight should default to the max height
+  minWidth,
   minHeight = maxHeight,
   shouldUseItemsHeight,
   isLoading,
@@ -198,6 +199,7 @@ export const Dropdown: FC<DropdownProps> = ({
 
   return (
     <StyledDropdownWrapperDiv
+      $minWidth={minWidth}
       $maxWidth={maxWidth}
       $maxHeight={headerAndFooterComponents.length === 0 ? maxDropdownHeight : undefined}
     >


### PR DESCRIPTION
### Description

Currently we have support for `minWidth` but it is not actually being used. This causes some issues like noted in https://github.com/frontapp/front-ui-kit/issues/173.