### PR TITLE
feat: add aria-invalid to Input

### DIFF
--- a/src/elements/input/__tests__/__snapshots__/input.spec.tsx.snap
+++ b/src/elements/input/__tests__/__snapshots__/input.spec.tsx.snap
@@ -90,6 +90,7 @@ exports[`<Checkbox /> Spec Snapshots should render a filled and disabled input 1
       class="c1"
     />
     <input
+      aria-invalid="false"
       class="c2"
       disabled=""
       id="id"
@@ -191,6 +192,7 @@ exports[`<Checkbox /> Spec Snapshots should render an empty and disabled input 1
       class="c1"
     />
     <input
+      aria-invalid="false"
       class="c2"
       disabled=""
       id="id"
@@ -304,6 +306,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input of type email 1`] = 
       </div>
     </div>
     <input
+      aria-invalid="false"
       class="c3"
       id="id"
       name=""
@@ -415,6 +418,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input of type number 1`] =
       </div>
     </div>
     <input
+      aria-invalid="false"
       class="c3"
       id="id"
       name=""
@@ -519,6 +523,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input with an error 1`] = 
       class="c1"
     />
     <input
+      aria-invalid="true"
       class="c2"
       id="id"
       name=""
@@ -630,6 +635,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input with an icon 1`] = `
       </div>
     </div>
     <input
+      aria-invalid="false"
       class="c3"
       id="id"
       name=""

--- a/src/elements/input/input.tsx
+++ b/src/elements/input/input.tsx
@@ -198,7 +198,6 @@ export function Input<T = string>(props: InputProps<T>) {
         onFocus={onInputFocus}
         onBlur={onInputBlur}
         aria-invalid={isErred}
-        aria-disabled={isDisabled}
       />
     </StyledInputDiv>
   );

--- a/src/elements/input/input.tsx
+++ b/src/elements/input/input.tsx
@@ -197,6 +197,8 @@ export function Input<T = string>(props: InputProps<T>) {
         onChange={onInputChange}
         onFocus={onInputFocus}
         onBlur={onInputBlur}
+        aria-invalid={isErred}
+        aria-disabled={isDisabled}
       />
     </StyledInputDiv>
   );


### PR DESCRIPTION
Will be used by `front-whatsapp` to easily jump to the first invalid input without having to resort to weird ID/classnames-based hacks and also should improve the accessibility of invalid inputs