### PR TITLE
fix: inline loader pngs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = {
       },
       {
         test: /\.(png|jpg|jpeg|gif)$/i,
-        type: 'asset/resource'
+        type: 'asset/inline'
       }
     ],
     generator: {


### PR DESCRIPTION
This is needed otherwise consumers will get an invalid URL for the loader images. If there's a better way to do this I'm happy to hear about it 😅 