### PR TITLE
fix(style): remove fixed height

### DIFF
--- a/src/components/formField/formField.tsx
+++ b/src/components/formField/formField.tsx
@@ -59,7 +59,6 @@ interface StyledFormFieldHelperTextDivProps {
 }
 
 const StyledFormFieldHelperTextDiv = styled.div<StyledFormFieldHelperTextDivProps>`
-  height: 14px;
   line-height: 14px;
   margin-top: -4px; // Minor offset to bring the hint and error closed to the input.
 


### PR DESCRIPTION
This little change allows form hints to go multi-line. This is an issue when building plugins for the sidebar where the space is limited (especially for laptop screens).

In our plugin, we have a hint that goes multi-line and the fixed height makes it overflow on the following text making it illegible.

I think it's fine removing the height as normally the line-height should take care of the situation of one line and multi-line without causing problems (at least for me :) ).