### PR TITLE
fix: migrate and pin actions in release-please-action SEC-704

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -11,12 +11,10 @@ jobs:
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445
         id: release
         with:
           release-type: node
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
 
   # Build and publish to NPM when a new version is released.
   build-and-publish:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,4 @@
+{
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+}


### PR DESCRIPTION
https://front.atlassian.net/browse/SEC-704

Now that we have allowlisted all existing GH actions, we should work to pin all to a full length SHA commit as a security measure in response to the tj-actions incident.

Safe to revert.

Saw to that `release-please-action` had migrated from old org to new one, plus new major upgrade moves configs to config json file instead of action param, so isolating this change to 1 PR due to increased risk.