### PR TITLE
preserve original svg viewbox values in icon component

### DIFF
--- a/src/components/button/__tests__/__snapshots__/button.spec.tsx.snap
+++ b/src/components/button/__tests__/__snapshots__/button.spec.tsx.snap
@@ -204,6 +204,7 @@ exports[`<Button /> Spec Snapshots should render icon button 1`] = `
         height="16"
         name="Close"
         preserveaspectratio="none"
+        viewbox="0 0 16 16"
         width="16"
       />
     </div>
@@ -246,6 +247,7 @@ exports[`<Button /> Spec Snapshots should render icon-danger button 1`] = `
         height="16"
         name="Close"
         preserveaspectratio="none"
+        viewbox="0 0 16 16"
         width="16"
       />
     </div>

--- a/src/components/checkbox/__tests__/__snapshots__/checkbox.spec.tsx.snap
+++ b/src/components/checkbox/__tests__/__snapshots__/checkbox.spec.tsx.snap
@@ -148,6 +148,7 @@ exports[`<Checkbox /> Spec Snapshots should render a checked and disabled checkb
             height="16"
             name="CheckmarkBox"
             preserveaspectratio="none"
+            viewbox="0 0 16 16"
             width="16"
           />
         </div>
@@ -237,6 +238,7 @@ exports[`<Checkbox /> Spec Snapshots should render a checked checkbox 1`] = `
             height="16"
             name="CheckmarkBox"
             preserveaspectratio="none"
+            viewbox="0 0 16 16"
             width="16"
           />
         </div>
@@ -465,6 +467,7 @@ exports[`<Checkbox /> Spec Snapshots should render an indeterminate and disabled
             height="16"
             name="Minus"
             preserveaspectratio="none"
+            viewbox="0 0 16 16"
             width="16"
           />
         </div>
@@ -554,6 +557,7 @@ exports[`<Checkbox /> Spec Snapshots should render an indeterminate checkbox 1`]
             height="16"
             name="Minus"
             preserveaspectratio="none"
+            viewbox="0 0 16 16"
             width="16"
           />
         </div>

--- a/src/components/pill/__tests__/__snapshots__/pill.spec.tsx.snap
+++ b/src/components/pill/__tests__/__snapshots__/pill.spec.tsx.snap
@@ -124,6 +124,7 @@ exports[`<Pill /> Spec Snapshots should support rendering a pill with icon 1`] =
           height="16"
           name="Checkmark"
           preserveaspectratio="none"
+          viewbox="0 0 16 16"
           width="16"
         />
       </div>

--- a/src/elements/icon/__tests__/__snapshots__/icon.spec.tsx.snap
+++ b/src/elements/icon/__tests__/__snapshots__/icon.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`<Icon /> Spec Snapshots should render with defaults 1`] = `
       height="16"
       name="Checkmark"
       preserveaspectratio="none"
+      viewbox="0 0 16 16"
       width="16"
     />
   </div>
@@ -42,6 +43,7 @@ exports[`<Icon /> Spec Snapshots should support different colors 1`] = `
       height="16"
       name="Checkmark"
       preserveaspectratio="none"
+      viewbox="0 0 16 16"
       width="16"
     />
   </div>
@@ -66,6 +68,7 @@ exports[`<Icon /> Spec Snapshots should support different sizes 1`] = `
       height="32"
       name="Checkmark"
       preserveaspectratio="none"
+      viewbox="0 0 16 16"
       width="32"
     />
   </div>

--- a/src/elements/icon/icon.tsx
+++ b/src/elements/icon/icon.tsx
@@ -168,16 +168,18 @@ export const Icon: FC<IconProps> = (props) => {
   const icon = icons[name];
   if (!icon) return null;
 
+  const iconProps: React.SVGAttributes<SVGElement> = {
+    name,
+    width: size,
+    height: size,
+    color: shouldDisableColor ? '' : color,
+    preserveAspectRatio: 'none',
+    viewBox: viewBox || '0 0 16 16',
+  };
+
   return (
     <StyledIconDiv $size={size}>
-      {icon({
-        name,
-        width: size,
-        height: size,
-        color: shouldDisableColor ? '' : color,
-        preserveAspectRatio: 'none',
-        viewBox,
-      })}
+      {icon(iconProps)}
     </StyledIconDiv>
   );
 };

--- a/src/elements/icon/icon.tsx
+++ b/src/elements/icon/icon.tsx
@@ -54,6 +54,7 @@ import Trash from '../../assets/icons/trash.svg';
 import TrashFilled from '../../assets/icons/trashFilled.svg';
 import WarningFilled from '../../assets/icons/warningFilled.svg';
 import { greys } from '../../helpers/colorHelpers';
+import { getIconViewBox } from './iconViewBoxes';
 
 /*
  * Constants.
@@ -174,7 +175,7 @@ export const Icon: FC<IconProps> = (props) => {
     height: size,
     color: shouldDisableColor ? '' : color,
     preserveAspectRatio: 'none',
-    viewBox: viewBox || '0 0 16 16',
+    viewBox: viewBox || getIconViewBox(name),
   };
 
   return (

--- a/src/elements/icon/iconViewBoxes.ts
+++ b/src/elements/icon/iconViewBoxes.ts
@@ -1,0 +1,21 @@
+// Generated metadata for original SVG viewBox values
+// Only stores exceptions - most icons use the default "0 0 16 16"
+// This ensures we can preserve the original viewBox from SVG files
+// when no viewBox prop is explicitly provided
+
+import type { IconName } from './icon';
+
+const ICON_VIEW_BOX_EXCEPTIONS: Partial<Record<IconName, string>> = {
+  Export: '0 0 16 17',
+  Info20: '0 0 20 20',
+};
+
+const DEFAULT_VIEW_BOX = '0 0 16 16';
+
+/**
+ * Gets the original viewBox for an icon name.
+ * Returns the exception viewBox if one exists, otherwise returns the default.
+ */
+export function getIconViewBox(iconName: IconName): string {
+  return ICON_VIEW_BOX_EXCEPTIONS[iconName] || DEFAULT_VIEW_BOX;
+}

--- a/src/elements/input/__tests__/__snapshots__/input.spec.tsx.snap
+++ b/src/elements/input/__tests__/__snapshots__/input.spec.tsx.snap
@@ -222,6 +222,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input of type email 1`] = 
           height="16"
           name="CheckmarkBox"
           preserveaspectratio="none"
+          viewbox="0 0 16 16"
           width="16"
         />
       </div>
@@ -310,6 +311,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input of type number 1`] =
           height="16"
           name="CheckmarkBox"
           preserveaspectratio="none"
+          viewbox="0 0 16 16"
           width="16"
         />
       </div>
@@ -476,6 +478,7 @@ exports[`<Checkbox /> Spec Snapshots should render an input with an icon 1`] = `
           height="16"
           name="CheckmarkBox"
           preserveaspectratio="none"
+          viewbox="0 0 16 16"
           width="16"
         />
       </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,15 +88,6 @@ module.exports = {
               typescript: true,
               jsx: true,
               svgo: true,
-              svgoConfig: {
-                // We want to keep the view box for the components.
-                plugins: [
-                  {
-                    name: 'removeViewBox',
-                    active: false
-                  }
-                ]
-              }
             }
           }
         ]


### PR DESCRIPTION
SVGO viewBox preservation is fundamentally incompatible with how SVGR works. SVGR generates React components where props completely override original SVG attributes - there's no way to "merge" or fallback to original values. Even with SVGO preserving viewBox in the source, passing any props to the component replaces all original attributes.

Instead, we now extract original viewBox values at build time and use a lookup function with exceptions (Export: 16x17, Info20: 20x20) while defaulting to 16x16 for standard icons.

Removes the SVGO viewBox config since the approach cannot work by design.
