### PR TITLE
feat: create nested dropdowns

### DIFF
--- a/src/elements/dropdown/__docs__/index.stories.tsx
+++ b/src/elements/dropdown/__docs__/index.stories.tsx
@@ -31,3 +31,10 @@ export {MultiLine} from './stories/multi-line.stories';
 export {Avatar} from './stories/avatar.stories';
 export {Header} from './stories/header.stories';
 export {Form} from './stories/form.stories';
+
+// Nested Dropdown Examples
+export {BasicNestedDropdown} from './stories/nestedDropdown.stories';
+export {CustomConfigDropdown} from './stories/nestedDropdown.stories';
+export {MultiSelectDropdown} from './stories/nestedDropdown.stories';
+export {LeftAlignedSubmenus} from './stories/nestedDropdown.stories';
+export {PerformanceTest} from './stories/nestedDropdown.stories';

--- a/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
+++ b/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
@@ -175,7 +175,14 @@ const Template: StoryFn = () => {
                     onSubmenuOpen={(id) => console.log('Opened submenu:', id)}
                     onSubmenuClose={(id) => console.log('Closed submenu:', id)}
                     submenu={
-                      <Dropdown>
+                      <Dropdown
+                        isEmpty={getFilteredItems(category.id, category.items).length === 0}
+                        renderEmptyState={() => (
+                          <EmptyState
+                            message="No results found. Try adjusting your search terms."
+                          />
+                        )}
+                      >
                         <DropdownHeader
                           searchValue={submenuSearchValues[category.id] || ''}
                           searchPlaceholder={`Search ${category.name.toLowerCase()}...`}
@@ -188,22 +195,16 @@ const Template: StoryFn = () => {
                           {category.name}
                         </DropdownHeader>
                         <DropdownHeading>{category.name}</DropdownHeading>
-                        {getFilteredItems(category.id, category.items).length === 0 ? (
-                          <EmptyState
-                            message="No results found. Try adjusting your search terms."
-                          />
-                        ) : (
-                          getFilteredItems(category.id, category.items).map((item) => (
-                            <DropdownItem 
-                              key={item} 
-                              onClick={() => {
-                                setSelectedValue(item);
-                                onRequestClose();
-                              }}>
-                              {item}
-                            </DropdownItem>
-                          ))
-                        )}
+                        {getFilteredItems(category.id, category.items).map((item) => (
+                          <DropdownItem 
+                            key={item} 
+                            onClick={() => {
+                              setSelectedValue(item);
+                              onRequestClose();
+                            }}>
+                            {item}
+                          </DropdownItem>
+                        ))}
                         <DropdownItem onClick={() => console.log('Settings clicked')}>
                           <DropdownItemIcon color={palette.orange.shade40} iconName="Gear" />
                           Settings
@@ -324,7 +325,14 @@ const MultiSelectTemplate: StoryFn = () => {
                       onSubmenuOpen={(id) => console.log('Opened multi-select submenu:', id)}
                       onSubmenuClose={(id) => console.log('Closed multi-select submenu:', id)}
                       submenu={
-                        <Dropdown>
+                        <Dropdown
+                          isEmpty={getFilteredItems(category.id, category.items).length === 0}
+                          renderEmptyState={() => (
+                            <EmptyState
+                              message="No results found. Try adjusting your search terms."
+                            />
+                          )}
+                        >
                           <DropdownHeader
                             searchValue={submenuSearchValues[category.id] || ''}
                             searchPlaceholder={`Search ${category.name.toLowerCase()}...`}
@@ -336,43 +344,15 @@ const MultiSelectTemplate: StoryFn = () => {
                             }}>
                             {category.name} ({selectedInCategory} selected)
                           </DropdownHeader>
-                          
-                          {getFilteredItems(category.id, category.items).length === 0 ? (
-                            <EmptyState
-                              message="No results found. Try adjusting your search terms."
-                            />
-                          ) : (
-                            <>
-                              <DropdownItem
+                            {getFilteredItems(category.id, category.items).map((item) => (
+                              <DropdownItem 
+                                key={item}
                                 type="multi"
-                                isSelected={selectedInCategory === category.items.length}
-                                onClick={() => {
-                                  if (selectedInCategory === category.items.length)
-                                    // Deselect all in this category
-                                    setSelectedItems(prev => 
-                                      prev.filter(item => !category.items.includes(item))
-                                    );
-                                  else
-                                    // Select all in this category
-                                    setSelectedItems(prev => [
-                                      ...prev.filter(item => !category.items.includes(item)),
-                                      ...category.items
-                                    ]);
-                                }}>
-                                <strong>Select All {category.name}</strong>
+                                isSelected={selectedItems.includes(item)}
+                                onClick={() => toggleItem(item)}>
+                                {item}
                               </DropdownItem>
-                              
-                              {getFilteredItems(category.id, category.items).map((item) => (
-                                <DropdownItem 
-                                  key={item}
-                                  type="multi"
-                                  isSelected={selectedItems.includes(item)}
-                                  onClick={() => toggleItem(item)}>
-                                  {item}
-                                </DropdownItem>
-                              ))}
-                            </>
-                          )}
+                            ))}
                         </Dropdown>
                       }>
                       <DropdownItemIcon 

--- a/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
+++ b/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
@@ -1,0 +1,524 @@
+import type {StoryFn} from '@storybook/react';
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+import {palette} from '../../../../helpers/colorHelpers';
+import {EmptyState} from '../../../emptyState/emptyState';
+import {NestedDropdownProvider} from '../../context/NestedDropdownContext';
+import {Dropdown} from '../../dropdown';
+import {DropdownButton} from '../../dropdownButton';
+import {DropdownCoordinator} from '../../dropdownCoordinator';
+import {DropdownHeader} from '../../dropdownHeader';
+import {DropdownHeading} from '../../dropdownHeading';
+import {DropdownItem} from '../../dropdownItem';
+import {DropdownItemIcon} from '../../dropdownItemIcon';
+
+const StyledWrapperDiv = styled.div`
+  display: flex;
+  flex-flow: row;
+  justify-content: center;
+  height: 500px;
+  padding: 20px;
+`;
+
+const StyledDropdownWrapperDiv = styled.div`
+  width: 260px;
+`;
+
+const categoriesData = [
+  {
+    id: 'animals',
+    name: 'Animals',
+    icon: 'Archive',
+    items: [
+      'Affenpinscher',
+      'Armant', 
+      'Bedlington Terrier',
+      'Boston Terrier',
+      'Bullmastiff',
+      'Chilean Fox Terrier',
+      'Dalmatian',
+      'English Water Spaniel',
+      'German Spitz',
+      'Hamiltonstövare'
+    ]
+  },
+  {
+    id: 'colors',
+    name: 'Colors',
+    icon: 'Star',
+    items: [
+      'Red',
+      'Blue', 
+      'Green',
+      'Yellow',
+      'Purple',
+      'Orange',
+      'Pink',
+      'Brown',
+      'Black',
+      'White'
+    ]
+  },
+  {
+    id: 'countries',
+    name: 'Countries',
+    icon: 'Calendar',
+    items: [
+      'United States',
+      'Canada',
+      'United Kingdom',
+      'Australia',
+      'Germany',
+      'France',
+      'Japan',
+      'Brazil',
+      'India',
+      'China'
+    ]
+  }
+];
+
+// Additional data for more complex examples
+const departmentsData = [
+  {
+    id: 'engineering',
+    name: 'Engineering',
+    icon: 'Gear',
+    teams: [
+      {
+        id: 'frontend',
+        name: 'Frontend',
+        members: ['Alice Johnson', 'Bob Smith', 'Carol Davis', 'David Wilson']
+      },
+      {
+        id: 'backend',
+        name: 'Backend', 
+        members: ['Eve Brown', 'Frank Miller', 'Grace Lee', 'Henry Taylor']
+      },
+      {
+        id: 'mobile',
+        name: 'Mobile',
+        members: ['Ivy Chen', 'Jack Anderson', 'Kate Martinez', 'Leo Garcia']
+      }
+    ]
+  },
+  {
+    id: 'design',
+    name: 'Design',
+    icon: 'Star',
+    teams: [
+      {
+        id: 'ux',
+        name: 'UX Design',
+        members: ['Maya Patel', 'Noah Kim', 'Olivia Rodriguez', 'Paul Thompson']
+      },
+      {
+        id: 'visual',
+        name: 'Visual Design',
+        members: ['Quinn White', 'Ruby Jackson', 'Sam Cooper', 'Tina Lewis']
+      }
+    ]
+  },
+  {
+    id: 'product',
+    name: 'Product',
+    icon: 'Calendar',
+    teams: [
+      {
+        id: 'strategy',
+        name: 'Strategy',
+        members: ['Uma Singh', 'Victor Clark', 'Wendy Hall', 'Xavier Young']
+      }
+    ]
+  }
+];
+
+const Template: StoryFn = () => {
+  const [selectedValue, setSelectedValue] = useState('');
+  const [submenuSearchValues, setSubmenuSearchValues] = useState<Record<string, string>>({});
+  const [filteredSubmenuItems, setFilteredSubmenuItems] = useState<Record<string, string[]>>({});
+
+  const getFilteredItems = (categoryId: string, items: string[]) => {
+    const searchValue = submenuSearchValues[categoryId] || '';
+    if (!searchValue) return items;
+    return items.filter(item => 
+      item.toLowerCase().includes(searchValue.toLowerCase())
+    );
+  };
+
+  return (
+    <StyledWrapperDiv>
+      <StyledDropdownWrapperDiv>
+        <NestedDropdownProvider
+          config={{
+            openDelay: 200,
+            closeDelay: 500,
+            maxDepth: 3,
+            placement: 'right-start'
+          }}>
+          <DropdownCoordinator
+            placement="bottom-start"
+            renderButton={(isOpen, isDisabled, buttonRef) => (
+              <DropdownButton 
+                value={selectedValue || 'Select Category'}
+                isActive={isOpen}
+              />
+            )}
+            renderDropdown={(onRequestClose) => (
+              <Dropdown>
+                <DropdownHeading>Categories</DropdownHeading>
+                {categoriesData.map((category) => (
+                  <DropdownItem
+                    key={category.id}
+                    submenuId={`category-${category.id}`}
+                    onSubmenuOpen={(id) => console.log('Opened submenu:', id)}
+                    onSubmenuClose={(id) => console.log('Closed submenu:', id)}
+                    submenu={
+                      <Dropdown>
+                        <DropdownHeader
+                          searchValue={submenuSearchValues[category.id] || ''}
+                          searchPlaceholder={`Search ${category.name.toLowerCase()}...`}
+                          onSearchChange={(newValue) => {
+                            setSubmenuSearchValues(prev => ({
+                              ...prev,
+                              [category.id]: newValue
+                            }));
+                          }}>
+                          {category.name}
+                        </DropdownHeader>
+                        <DropdownHeading>{category.name}</DropdownHeading>
+                        {getFilteredItems(category.id, category.items).length === 0 ? (
+                          <EmptyState
+                            message="No results found. Try adjusting your search terms."
+                          />
+                        ) : (
+                          getFilteredItems(category.id, category.items).map((item) => (
+                            <DropdownItem 
+                              key={item} 
+                              onClick={() => {
+                                setSelectedValue(item);
+                                onRequestClose();
+                              }}>
+                              {item}
+                            </DropdownItem>
+                          ))
+                        )}
+                        <DropdownItem onClick={() => console.log('Settings clicked')}>
+                          <DropdownItemIcon color={palette.orange.shade40} iconName="Gear" />
+                          Settings
+                        </DropdownItem>
+                      </Dropdown>
+                    }>
+                    <DropdownItemIcon 
+                      color={palette.blue.shade40} 
+                      iconName={category.icon as 'Archive' | 'Star' | 'Calendar'} 
+                    />
+                    {category.name}
+                  </DropdownItem>
+                ))}
+              </Dropdown>
+            )}
+          />
+        </NestedDropdownProvider>
+      </StyledDropdownWrapperDiv>
+    </StyledWrapperDiv>
+  );
+};
+
+export const BasicNestedDropdown = Template.bind({});
+
+export const CustomConfigDropdown = Template.bind({});
+CustomConfigDropdown.storyName = 'Custom Configuration';
+CustomConfigDropdown.decorators = [
+  (Story) => (
+    <NestedDropdownProvider
+      config={{
+        openDelay: 50,
+        closeDelay: 500,
+        maxDepth: 3,
+        placement: 'right-start',
+        enableKeyboardNavigation: true,
+        layerIdPrefix: 'custom-nested'
+      }}>
+      <Story />
+    </NestedDropdownProvider>
+  )
+];
+
+// Multi-select nested dropdown example
+const MultiSelectTemplate: StoryFn = () => {
+  const [selectedItems, setSelectedItems] = useState<string[]>([]);
+  const [submenuSearchValues, setSubmenuSearchValues] = useState<Record<string, string>>({});
+
+  const getFilteredItems = (categoryId: string, items: string[]) => {
+    const searchValue = submenuSearchValues[categoryId] || '';
+    if (!searchValue) return items;
+    return items.filter(item => 
+      item.toLowerCase().includes(searchValue.toLowerCase())
+    );
+  };
+
+  const toggleItem = (item: string) => {
+    setSelectedItems(prev => 
+      prev.includes(item)
+        ? prev.filter(i => i !== item)
+        : [...prev, item]
+    );
+  };
+
+  const clearSelection = () => {
+    setSelectedItems([]);
+  };
+
+  const getSelectedByCategory = (categoryItems: string[]) => 
+    categoryItems.filter(item => selectedItems.includes(item)).length;
+
+  return (
+    <StyledWrapperDiv>
+      <StyledDropdownWrapperDiv>
+        <NestedDropdownProvider
+          config={{
+            openDelay: 200,
+            closeDelay: 400,
+            maxDepth: 3,
+            placement: 'right-start'
+          }}>
+          <DropdownCoordinator
+            placement="bottom-start"
+            renderButton={(isOpen, isDisabled, buttonRef) => (
+              <DropdownButton 
+                value={selectedItems.length > 0 ? selectedItems : []}
+                placeholder="Select multiple items"
+                isActive={isOpen}
+              />
+            )}
+            renderDropdown={(onRequestClose) => (
+              <Dropdown>
+                <DropdownHeader>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <span>Multi-Select Categories</span>
+                    {selectedItems.length > 0 && (
+                      <button 
+                        type="button"
+                        onClick={clearSelection}
+                        style={{ 
+                          background: 'none', 
+                          border: 'none', 
+                          color: '#007bff', 
+                          cursor: 'pointer',
+                          fontSize: '12px'
+                        }}>
+                        Clear All
+                      </button>
+                    )}
+                  </div>
+                </DropdownHeader>
+                
+                {categoriesData.map((category) => {
+                  const selectedInCategory = getSelectedByCategory(category.items);
+                  return (
+                    <DropdownItem
+                      key={category.id}
+                      submenuId={`multi-${category.id}`}
+                      onSubmenuOpen={(id) => console.log('Opened multi-select submenu:', id)}
+                      onSubmenuClose={(id) => console.log('Closed multi-select submenu:', id)}
+                      submenu={
+                        <Dropdown>
+                          <DropdownHeader
+                            searchValue={submenuSearchValues[category.id] || ''}
+                            searchPlaceholder={`Search ${category.name.toLowerCase()}...`}
+                            onSearchChange={(newValue) => {
+                              setSubmenuSearchValues(prev => ({
+                                ...prev,
+                                [category.id]: newValue
+                              }));
+                            }}>
+                            {category.name} ({selectedInCategory} selected)
+                          </DropdownHeader>
+                          
+                          {getFilteredItems(category.id, category.items).length === 0 ? (
+                            <EmptyState
+                              message="No results found. Try adjusting your search terms."
+                            />
+                          ) : (
+                            <>
+                              <DropdownItem
+                                type="multi"
+                                isSelected={selectedInCategory === category.items.length}
+                                onClick={() => {
+                                  if (selectedInCategory === category.items.length)
+                                    // Deselect all in this category
+                                    setSelectedItems(prev => 
+                                      prev.filter(item => !category.items.includes(item))
+                                    );
+                                  else
+                                    // Select all in this category
+                                    setSelectedItems(prev => [
+                                      ...prev.filter(item => !category.items.includes(item)),
+                                      ...category.items
+                                    ]);
+                                }}>
+                                <strong>Select All {category.name}</strong>
+                              </DropdownItem>
+                              
+                              {getFilteredItems(category.id, category.items).map((item) => (
+                                <DropdownItem 
+                                  key={item}
+                                  type="multi"
+                                  isSelected={selectedItems.includes(item)}
+                                  onClick={() => toggleItem(item)}>
+                                  {item}
+                                </DropdownItem>
+                              ))}
+                            </>
+                          )}
+                        </Dropdown>
+                      }>
+                      <DropdownItemIcon 
+                        color={palette.purple.shade40} 
+                        iconName={category.icon as 'Archive' | 'Star' | 'Calendar'} 
+                      />
+                      {category.name}
+                    </DropdownItem>
+                  );
+                })}
+              </Dropdown>
+            )}
+          />
+        </NestedDropdownProvider>
+      </StyledDropdownWrapperDiv>
+    </StyledWrapperDiv>
+  );
+};
+
+export const MultiSelectDropdown = MultiSelectTemplate.bind({});
+MultiSelectDropdown.storyName = 'Multi-Select with Submenus';
+
+// Left-aligned submenu example
+const LeftAlignedTemplate: StoryFn = () => (
+  <StyledWrapperDiv style={{ justifyContent: 'flex-end' }}>
+    <StyledDropdownWrapperDiv>
+      <NestedDropdownProvider
+        config={{
+          placement: 'left-start',
+          openDelay: 150,
+          closeDelay: 400
+        }}>
+        <DropdownCoordinator
+          placement="bottom-start"
+          renderButton={(isOpen, isDisabled, buttonRef) => (
+            <DropdownButton 
+              value="Left-Aligned Submenus"
+              isActive={isOpen}
+            />
+          )}
+          renderDropdown={(onRequestClose) => (
+            <Dropdown>
+              <DropdownHeading>Categories (Left-Aligned)</DropdownHeading>
+              {categoriesData.map((category) => (
+                <DropdownItem
+                  key={category.id}
+                  submenuId={`left-${category.id}`}
+                  submenu={
+                    <Dropdown>
+                      <DropdownHeading>{category.name}</DropdownHeading>
+                      {category.items.map((item) => (
+                        <DropdownItem key={item} onClick={() => console.log('Selected:', item)}>
+                          {item}
+                        </DropdownItem>
+                      ))}
+                    </Dropdown>
+                  }>
+                  <DropdownItemIcon 
+                    color={palette.purple.shade40} 
+                    iconName={category.icon as 'Archive' | 'Star' | 'Calendar'} 
+                  />
+                  {category.name}
+                </DropdownItem>
+              ))}
+            </Dropdown>
+          )}
+        />
+      </NestedDropdownProvider>
+    </StyledDropdownWrapperDiv>
+  </StyledWrapperDiv>
+);
+
+export const LeftAlignedSubmenus = LeftAlignedTemplate.bind({});
+LeftAlignedSubmenus.storyName = 'Left-Aligned Submenus';
+
+// Performance test with many items
+const PerformanceTemplate: StoryFn = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  
+  // Generate large dataset
+  const largeDataset = Array.from({ length: 10 }, (_, categoryIndex) => ({
+    id: `category-${categoryIndex}`,
+    name: `Category ${categoryIndex + 1}`,
+    icon: 'Archive',
+    items: Array.from({ length: 100 }, (__, itemIndex) => 
+      `Item ${categoryIndex + 1}-${itemIndex + 1}`
+    )
+  }));
+
+  const filteredData = largeDataset.map(category => ({
+    ...category,
+    items: category.items.filter(item => 
+      item.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+  })).filter(category => 
+    category.name.toLowerCase().includes(searchTerm.toLowerCase()) || 
+    category.items.length > 0
+  );
+
+  return (
+    <StyledWrapperDiv>
+      <StyledDropdownWrapperDiv>
+        <NestedDropdownProvider>
+          <DropdownCoordinator
+            placement="bottom-start"
+            renderButton={(isOpen, isDisabled, buttonRef) => (
+              <DropdownButton 
+                value="Performance Test (1000+ Items)"
+                isActive={isOpen}
+              />
+            )}
+            renderDropdown={(onRequestClose) => (
+              <Dropdown>
+                <DropdownHeader
+                  searchValue={searchTerm}
+                  searchPlaceholder="Search items..."
+                  onSearchChange={setSearchTerm}>
+                  Performance Test
+                </DropdownHeader>
+                
+                {filteredData.map((category) => (
+                  <DropdownItem
+                    key={category.id}
+                    submenuId={`perf-${category.id}`}
+                    submenu={
+                        <Dropdown maxHeight={400}>
+                        <DropdownHeading>{category.name} ({category.items.length} items)</DropdownHeading>
+                        {category.items.map((item) => (
+                          <DropdownItem key={item} onClick={() => console.log('Selected:', item)}>
+                            {item}
+                          </DropdownItem>
+                        ))}
+                      </Dropdown>
+                    }>
+                    <DropdownItemIcon color={palette.orange.shade40} iconName="Archive" />
+                    {category.name} ({category.items.length})
+                  </DropdownItem>
+                ))}
+              </Dropdown>
+            )}
+          />
+        </NestedDropdownProvider>
+      </StyledDropdownWrapperDiv>
+    </StyledWrapperDiv>
+  );
+};
+
+export const PerformanceTest = PerformanceTemplate.bind({});
+PerformanceTest.storyName = 'Performance Test (Large Dataset)';

--- a/src/elements/dropdown/components/SubmenuTrigger.tsx
+++ b/src/elements/dropdown/components/SubmenuTrigger.tsx
@@ -1,0 +1,300 @@
+import {type Placement} from '@popperjs/core';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {usePopper} from 'react-popper';
+import { styled } from 'styled-components';
+
+import {Layer} from '../../../components/layer/layer';
+import {useNestedDropdown, useSubmenu} from '../context/NestedDropdownContext';
+import {useSubmenuPositioning} from '../hooks/useSubmenuPositioning';
+import {SubmenuCapableProps} from '../types/nestedDropdown';
+
+interface SubmenuTriggerProps extends SubmenuCapableProps {
+  children: React.ReactNode;
+  /** Parent submenu ID for nesting */
+  parentSubmenuId?: string;
+  /** Custom class name */
+  className?: string;
+  /** Whether this trigger is disabled */
+  disabled?: boolean;
+}
+
+const StyledSubmenuTriggerDiv = styled.div`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  
+  /* Ensure proper cursor and interaction states */
+  cursor: pointer;
+  
+  /* Maintain consistent styling with dropdown items */
+  &:hover {
+    /* Let the child dropdown item handle hover styles */
+  }
+  
+  /* Ensure submenu trigger takes full space of dropdown item */
+  & > * {
+    flex: 1;
+  }
+`;
+
+const StyledSubmenuContentWrapper = styled.div`
+  /* Wrapper for submenu content to ensure proper event handling */
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+`;
+
+/**
+ * SubmenuTrigger component handles the display and positioning of dropdown submenus.
+ * 
+ * This component wraps dropdown items that have submenus and manages:
+ * - Hover state for opening/closing submenus
+ * - Custom Popper.js positioning that bypasses PopoverContext
+ * - Mouse event handling for smooth submenu interactions
+ * 
+ * The positioning implementation uses direct Popper.js integration instead of 
+ * PopoverContext to avoid conflicts with the main dropdown's context and ensure
+ * precise positioning relative to individual dropdown items.
+ */
+export const SubmenuTrigger: React.FC<SubmenuTriggerProps> = ({
+  children,
+  submenuId,
+  submenu,
+  parentSubmenuId,
+  className,
+  disabled = false,
+  onSubmenuOpen,
+  onSubmenuClose,
+  submenuConfig
+}) => {
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const {config} = useNestedDropdown();
+  const effectiveConfig = {...config, ...submenuConfig};
+  
+  // Generate a deterministic ID if none provided (must be called unconditionally)
+  const generatedId = React.useId();
+  const effectiveSubmenuId = submenuId ?? `submenu-${generatedId}`;
+  
+  const {
+    isOpen,
+    level,
+    open,
+    close,
+    setHover,
+    canOpen
+  } = useSubmenu(effectiveSubmenuId);
+  
+  
+  const {getPositioning} = useSubmenuPositioning({
+    submenuId: effectiveSubmenuId,
+    level,
+    placement: effectiveConfig.placement,
+    layerIdPrefix: effectiveConfig.layerIdPrefix
+  });
+  
+
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (disabled || !submenu || !canOpen(parentSubmenuId)) return;
+    
+    
+    // Clear any existing timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    
+    // Set hover to true immediately to prevent closing
+    setHover(true);
+    
+    timeoutRef.current = setTimeout(() => {
+      if (triggerRef.current) {
+        open(parentSubmenuId);
+        onSubmenuOpen?.(effectiveSubmenuId);
+      }
+    }, effectiveConfig.openDelay);
+  }, [disabled, submenu, canOpen, parentSubmenuId, open, onSubmenuOpen, effectiveSubmenuId, effectiveConfig.openDelay, setHover]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (disabled || !submenu) return;
+    
+    
+    // Clear any pending open timeout
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    
+    // Always set hover to false when leaving trigger
+    // The submenu mouse enter will set it back to true if mouse moves to submenu
+    setHover(false);
+  }, [disabled, submenu, setHover]);
+
+  const handleSubmenuMouseEnter = useCallback(() => {
+    if (disabled) return;
+    setHover(true);
+  }, [disabled, setHover]);
+
+  const handleSubmenuMouseLeave = useCallback(() => {
+    if (disabled) return;
+    setHover(false);
+    // Call onSubmenuClose when submenu is closed via mouse leave
+    onSubmenuClose?.(effectiveSubmenuId);
+  }, [disabled, setHover, onSubmenuClose, effectiveSubmenuId]);
+
+  // Cleanup on unmount and call onSubmenuClose when closing
+  useEffect(() => () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    close();
+    onSubmenuClose?.(effectiveSubmenuId);
+  }, [close, onSubmenuClose, effectiveSubmenuId]);
+
+  // Use the individual trigger item as anchor element for positioning
+  const getAnchorElement = useCallback(() => {
+    if (!triggerRef.current) return null;
+    
+    // Ensure we're using the actual dropdown item element, not any parent containers
+    const itemElement = triggerRef.current.closest('[role="menuitem"]') || triggerRef.current;
+    return itemElement instanceof HTMLElement ? itemElement : triggerRef.current;
+  }, []);
+
+  const anchorElement = getAnchorElement();
+  const positioning = anchorElement ? getPositioning(anchorElement) : null;
+  
+
+  return (
+    <>
+      <StyledSubmenuTriggerDiv
+        ref={triggerRef}
+        className={className}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        role={submenu ? 'menuitem' : undefined}
+        aria-haspopup={submenu ? 'menu' : undefined}
+        aria-expanded={submenu ? isOpen : undefined}
+        data-submenu-trigger={submenu ? 'true' : undefined}
+        data-submenu-level={level}
+        data-submenu-id={effectiveSubmenuId}>
+        {children}
+      </StyledSubmenuTriggerDiv>
+      
+      
+      {isOpen && submenu && positioning && (
+        <SubmenuPortal
+          positioning={positioning}
+          onMouseEnter={handleSubmenuMouseEnter}
+          onMouseLeave={handleSubmenuMouseLeave}
+          submenuId={effectiveSubmenuId}
+          triggerElement={triggerRef.current}>
+          <StyledSubmenuContentWrapper
+            onMouseEnter={handleSubmenuMouseEnter}
+            onMouseLeave={handleSubmenuMouseLeave}>
+            {submenu}
+          </StyledSubmenuContentWrapper>
+        </SubmenuPortal>
+      )}
+    </>
+  );
+};
+
+// Separate component for the portal to avoid re-renders
+/**
+ * Props for the SubmenuPortal component
+ */
+interface SubmenuPortalProps {
+  positioning: {
+    anchorElement: HTMLElement;
+    placement: Placement;
+    zIndex: number;
+    layerId: string;
+  };
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  submenuId: string;
+  triggerElement: HTMLElement | null;
+  children: React.ReactNode;
+}
+
+/**
+ * SubmenuPortal renders the submenu in a portal with custom Popper.js positioning.
+ * 
+ * This component bypasses the PopoverContext system to avoid conflicts with the
+ * main dropdown's positioning context. It uses direct Popper.js integration to
+ * position the submenu relative to the specific trigger element.
+ */
+const SubmenuPortal: React.FC<SubmenuPortalProps> = ({
+  positioning,
+  onMouseEnter,
+  onMouseLeave,
+  submenuId,
+  triggerElement,
+  children
+}) => {
+  /**
+   * Custom Popper.js implementation for submenu positioning.
+   * 
+   * We bypass the PopoverContext system here because:
+   * 1. The main dropdown already has a PopoverContext that anchors to the dropdown coordinator
+   * 2. We need to anchor specifically to the individual dropdown item, not the coordinator
+   * 3. This avoids context conflicts and gives us precise control over submenu positioning
+   */
+
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  
+  // Direct Popper.js usage with the specific trigger element as anchor
+  const { styles, attributes } = usePopper(triggerElement, popperElement, {
+    placement: positioning.placement,
+    modifiers: [
+      {
+        name: 'computeStyles',
+        options: {
+          gpuAcceleration: false
+        }
+      },
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 8] // 8px gap between trigger and submenu
+        }
+      },
+      {
+        name: 'preventOverflow',
+        options: {
+          padding: 10,
+          boundary: window.document.body
+        }
+      }
+    ]
+  });
+
+  return (
+    <Layer layerRootId={positioning.layerId}>
+      <div
+        ref={setPopperElement}
+        style={styles.popper}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...attributes.popper}>
+        <div
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          data-submenu-portal={submenuId}
+          role="menu"
+          tabIndex={-1}
+          aria-labelledby={`trigger-${submenuId}`}
+          style={{ 
+            zIndex: positioning.zIndex,
+            pointerEvents: 'auto',
+            width: 'auto',
+            minWidth: '200px',
+            maxWidth: '400px'
+          }}>
+          {children}
+        </div>
+      </div>
+    </Layer>
+  );
+};
+

--- a/src/elements/dropdown/context/NestedDropdownContext.tsx
+++ b/src/elements/dropdown/context/NestedDropdownContext.tsx
@@ -1,0 +1,325 @@
+import React, {createContext, useCallback, useContext, useMemo, useRef, useState} from 'react';
+
+import {
+  DEFAULT_NESTED_CONFIG,
+  NestedDropdownConfig,
+  NestedDropdownContextValue,
+  SubmenuState
+} from '../types/nestedDropdown';
+
+/**
+ * React Context for managing nested dropdown state across the component tree.
+ * Provides centralized state management for all submenus, including their open/close state,
+ * hover state, nesting levels, and timeout management.
+ */
+export const NestedDropdownContext = createContext<NestedDropdownContextValue | null>(null);
+
+/**
+ * Props for the NestedDropdownProvider component.
+ */
+interface NestedDropdownProviderProps {
+  /** Child components that will have access to the nested dropdown context */
+  children: React.ReactNode;
+  /** Configuration options for nested dropdown behavior. Will be merged with defaults */
+  config?: Partial<NestedDropdownConfig>;
+}
+
+/**
+ * Provider component that manages the state for all nested dropdowns within its tree.
+ * 
+ * This component provides:
+ * - Centralized state management for all submenus
+ * - Timeout management for hover delays
+ * - Level-based z-index calculation
+ * - Automatic cleanup of child submenus when parents close
+ * 
+ * @example
+ * ```tsx
+ * <NestedDropdownProvider config={{ openDelay: 200, closeDelay: 500 }}>
+ *   <DropdownCoordinator>
+ *     <DropdownItem submenu={<Dropdown>...</Dropdown>}>
+ *       Parent Item
+ *     </DropdownItem>
+ *   </DropdownCoordinator>
+ * </NestedDropdownProvider>
+ * ```
+ */
+export const NestedDropdownProvider: React.FC<NestedDropdownProviderProps> = ({
+  children,
+  config: userConfig = {}
+}) => {
+  const [submenus, setSubmenus] = useState<Map<string, SubmenuState>>(new Map());
+  const timeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  
+  const config = useMemo(
+    () => ({...DEFAULT_NESTED_CONFIG, ...userConfig}),
+    [userConfig]
+  );
+
+  /**
+   * Clears any pending timeout for a specific submenu.
+   * Used to cancel delayed open/close operations when user interaction changes.
+   * 
+   * @param id - The unique identifier of the submenu
+   */
+  const clearTimeout = useCallback((id: string) => {
+    const timeout = timeoutsRef.current.get(id);
+    if (timeout) {
+      global.clearTimeout(timeout);
+      timeoutsRef.current.delete(id);
+    }
+  }, []);
+
+  /**
+   * Opens a submenu and manages the hierarchical state.
+   * 
+   * This function:
+   * - Calculates the nesting level based on the parent
+   * - Enforces maximum depth limits
+   * - Closes conflicting submenus at the same level or deeper
+   * - Sets up the submenu state with proper hierarchy
+   * 
+   * @param id - Unique identifier for the submenu to open
+   * @param parentId - Optional parent submenu ID for hierarchy calculation
+   */
+  const openSubmenu = useCallback((id: string, parentId?: string) => {
+    clearTimeout(id);
+    
+    setSubmenus(prev => {
+      const newSubmenus = new Map(prev);
+      const level = parentId ? (prev.get(parentId)?.level ?? 0) + 1 : 0;
+      
+      // Check max depth
+      if (level >= config.maxDepth) 
+        // Maximum nesting depth exceeded - silently ignore
+        return prev;
+      
+      // Close any existing submenus at this level or deeper
+      newSubmenus.forEach((submenu, submenuId) => {
+        if (submenu.level >= level && submenuId !== id) 
+          newSubmenus.delete(submenuId);
+        
+      });
+      
+      newSubmenus.set(id, {
+        isOpen: true,
+        isHovered: false,
+        id,
+        level,
+        parentId
+      });
+      
+      return newSubmenus;
+    });
+  }, [config.maxDepth, clearTimeout]);
+
+  /**
+   * Closes a submenu after a configured delay, unless it's being hovered.
+   * 
+   * This function:
+   * - Respects the closeDelay configuration for smooth UX
+   * - Only closes if the submenu is not currently hovered
+   * - Automatically closes all child submenus when a parent closes
+   * - Manages timeout cleanup to prevent memory leaks
+   * 
+   * @param id - Unique identifier for the submenu to close
+   */
+  const closeSubmenu = useCallback((id: string) => {
+    clearTimeout(id);
+    
+    const timeout = global.setTimeout(() => {
+      setSubmenus(prev => {
+        const newSubmenus = new Map(prev);
+        const submenu = newSubmenus.get(id);
+        
+        if (submenu && !submenu.isHovered) {
+          // Close this submenu and all its children
+          newSubmenus.forEach((childSubmenu, childId) => {
+            if (childSubmenu.level > submenu.level) 
+              newSubmenus.delete(childId);
+            
+          });
+          newSubmenus.delete(id);
+        }
+        
+        return newSubmenus;
+      });
+    }, config.closeDelay);
+    
+    timeoutsRef.current.set(id, timeout);
+  }, [config.closeDelay, clearTimeout]);
+
+  /**
+   * Immediately closes all submenus at or deeper than the specified level.
+   * Used for cleanup when a parent submenu closes or when resetting state.
+   * 
+   * @param level - The minimum nesting level to close (inclusive)
+   */
+  const closeSubmenusFromLevel = useCallback((level: number) => {
+    setSubmenus(prev => {
+      const newSubmenus = new Map(prev);
+      newSubmenus.forEach((submenu, id) => {
+        if (submenu.level >= level) {
+          clearTimeout(id);
+          newSubmenus.delete(id);
+        }
+      });
+      return newSubmenus;
+    });
+  }, [clearTimeout]);
+
+  /**
+   * Updates the hover state of a submenu and manages associated timeouts.
+   * 
+   * When hovering starts:
+   * - Cancels any pending close timeout
+   * - Updates the hover state to prevent automatic closing
+   * 
+   * When hovering ends:
+   * - Initiates the close sequence with delay
+   * 
+   * @param id - Unique identifier for the submenu
+   * @param isHovered - Whether the submenu is currently being hovered
+   */
+  const setSubmenuHover = useCallback((id: string, isHovered: boolean) => {
+    setSubmenus(prev => {
+      const newSubmenus = new Map(prev);
+      const submenu = newSubmenus.get(id);
+      
+      if (submenu) newSubmenus.set(id, {...submenu, isHovered});
+      
+      return newSubmenus;
+    });
+    
+    if (isHovered) clearTimeout(id);
+    else closeSubmenu(id);
+  }, [clearTimeout, closeSubmenu]);
+
+  /**
+   * Gets the nesting level of a specific submenu.
+   * 
+   * @param id - Unique identifier for the submenu
+   * @returns The nesting level (0 for top-level, 1 for first nested, etc.)
+   */
+  const getSubmenuLevel = useCallback((id: string): number => submenus.get(id)?.level ?? 0, [submenus]);
+
+  /**
+   * Checks if a new submenu can be opened based on maximum depth constraints.
+   * 
+   * @param parentId - Optional parent submenu ID
+   * @returns True if the submenu can be opened without exceeding maxDepth
+   */
+  const canOpenSubmenu = useCallback((parentId?: string): boolean => {
+    const parentLevel = parentId ? getSubmenuLevel(parentId) : -1;
+    return parentLevel + 1 < config.maxDepth;
+  }, [config.maxDepth, getSubmenuLevel]);
+
+  const contextValue = useMemo<NestedDropdownContextValue>(() => ({
+    config,
+    submenus,
+    openSubmenu,
+    closeSubmenu,
+    closeSubmenusFromLevel,
+    setSubmenuHover,
+    getSubmenuLevel,
+    canOpenSubmenu
+  }), [
+    config,
+    submenus,
+    openSubmenu,
+    closeSubmenu,
+    closeSubmenusFromLevel,
+    setSubmenuHover,
+    getSubmenuLevel,
+    canOpenSubmenu
+  ]);
+
+  // Cleanup timeouts on unmount
+  React.useEffect(() => () => {
+      timeoutsRef.current.forEach(timeout => global.clearTimeout(timeout));
+      timeoutsRef.current.clear();
+    }, []);
+
+  return (
+    <NestedDropdownContext.Provider value={contextValue}>
+      {children}
+    </NestedDropdownContext.Provider>
+  );
+};
+
+/**
+ * Hook to access the nested dropdown context.
+ * Must be used within a NestedDropdownProvider.
+ * 
+ * @returns The nested dropdown context value with all state and methods
+ * @throws Error if used outside of a NestedDropdownProvider
+ * 
+ * @example
+ * ```tsx
+ * const { openSubmenu, closeSubmenu, config } = useNestedDropdown();
+ * ```
+ */
+export const useNestedDropdown = (): NestedDropdownContextValue => {
+  const context = useContext(NestedDropdownContext);
+  if (!context) 
+    throw new Error('useNestedDropdown must be used within a NestedDropdownProvider');
+  
+  return context;
+};
+
+/**
+ * Hook for managing a specific submenu's state and interactions.
+ * Provides a convenient interface for individual submenu components.
+ * 
+ * @param id - Unique identifier for the submenu
+ * @returns Object containing submenu state and control methods
+ * 
+ * @example
+ * ```tsx
+ * const { isOpen, open, close, setHover, canOpen } = useSubmenu('my-submenu-id');
+ * 
+ * // Open the submenu with a parent context
+ * const handleMouseEnter = () => {
+ *   if (canOpen(parentId)) {
+ *     open(parentId);
+ *   }
+ * };
+ * 
+ * // Update hover state
+ * const handleMouseLeave = () => setHover(false);
+ * ```
+ */
+export const useSubmenu = (id: string) => {
+  const {
+    submenus,
+    openSubmenu,
+    closeSubmenu,
+    setSubmenuHover,
+    canOpenSubmenu
+  } = useNestedDropdown();
+  
+  const submenuState = submenus.get(id);
+  
+  const open = useCallback((parentId?: string) => openSubmenu(id, parentId), [openSubmenu, id]);
+  const close = useCallback(() => closeSubmenu(id), [closeSubmenu, id]);
+  const setHover = useCallback((isHovered: boolean) => setSubmenuHover(id, isHovered), [setSubmenuHover, id]);
+  const canOpen = useCallback((parentId?: string) => canOpenSubmenu(parentId), [canOpenSubmenu]);
+  
+  return {
+    /** Whether the submenu is currently open */
+    isOpen: submenuState?.isOpen ?? false,
+    /** Whether the submenu is currently being hovered */
+    isHovered: submenuState?.isHovered ?? false,
+    /** The nesting level of this submenu (0 = top level) */
+    level: submenuState?.level ?? 0,
+    /** Function to open this submenu */
+    open,
+    /** Function to close this submenu */
+    close,
+    /** Function to update hover state */
+    setHover,
+    /** Function to check if submenu can be opened */
+    canOpen
+  };
+};
+

--- a/src/elements/dropdown/context/NestedDropdownContext.tsx
+++ b/src/elements/dropdown/context/NestedDropdownContext.tsx
@@ -90,9 +90,11 @@ export const NestedDropdownProvider: React.FC<NestedDropdownProviderProps> = ({
       const level = parentId ? (prev.get(parentId)?.level ?? 0) + 1 : 0;
       
       // Check max depth
-      if (level >= config.maxDepth) 
-        // Maximum nesting depth exceeded - silently ignore
+      if (level >= config.maxDepth) {
+        // eslint-disable-next-line no-console
+        console.warn(`Maximum nesting depth exceeded for submenu ${id}`);
         return prev;
+      }
       
       // Close any existing submenus at this level or deeper
       newSubmenus.forEach((submenu, submenuId) => {

--- a/src/elements/dropdown/dropdown.tsx
+++ b/src/elements/dropdown/dropdown.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, {FC, useMemo} from 'react';
+import React, {FC, isValidElement, useMemo} from 'react';
 import styled, {css} from 'styled-components';
 
 import {greys} from '../../helpers/colorHelpers';
@@ -164,6 +164,14 @@ export const Dropdown: FC<DropdownProps> = ({
     [children]
   );
 
+  // Check if any children have submenus to determine if we need persistent rendering
+  const hasSubmenus = useMemo(() => 
+    React.Children.toArray(children).some(child => {
+      if (!isValidElement(child) || !child.props) return false;
+      const childProps = child.props as Record<string, unknown>;
+      return 'submenu' in childProps && Boolean(childProps.submenu);
+    }), [children]);
+
   const renderDropdownContent = () => {
     if (isEmpty && renderEmptyState) return renderEmptyState();
     // We will not support rendering the input items in the list. Since the virtual list re-renders so often
@@ -192,6 +200,7 @@ export const Dropdown: FC<DropdownProps> = ({
         getItemHeight={getItemHeight}
         renderItem={renderItem}
         onLoadMore={onLoadMore || (async () => {})}
+        isPersistent={hasSubmenus}
       />
     );
   };
@@ -200,7 +209,8 @@ export const Dropdown: FC<DropdownProps> = ({
     <StyledDropdownWrapperDiv
       $minWidth={minWidth}
       $maxWidth={maxWidth}
-      $maxHeight={headerAndFooterComponents.length === 0 ? maxDropdownHeight : undefined}>
+      $maxHeight={headerAndFooterComponents.length === 0 ? maxDropdownHeight : undefined}
+      data-dropdown-container="true">
       {/* Render Dropdown headers / footers. */}
       {headerAndFooterComponents}
       <StyledDropdownContentWrapperDiv

--- a/src/elements/dropdown/dropdown.tsx
+++ b/src/elements/dropdown/dropdown.tsx
@@ -81,9 +81,10 @@ const StyledDropdownWrapperDiv = styled.div<StyledDropdownWrapperDivProps>`
     max-width: ${p.$maxWidth}px;
   `}
   ${(p) =>
+    // We add 2px to the max height to account for the border of the dropdown.
     p.$maxHeight &&
     css`
-      max-height: ${p.$maxHeight}px;
+      max-height: ${p.$maxHeight + 2}px;
     `};
   ${(p) =>
     p.$minWidth &&

--- a/src/elements/dropdown/dropdownList.tsx
+++ b/src/elements/dropdown/dropdownList.tsx
@@ -1,6 +1,7 @@
 import React, {ComponentType, FC, forwardRef, useEffect, useRef} from 'react';
 import {ListChildComponentProps, VariableSizeList} from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
+import styled from 'styled-components';
 
 import {usePrevious} from '../../helpers/hookHelpers';
 
@@ -9,6 +10,27 @@ import {usePrevious} from '../../helpers/hookHelpers';
  */
 
 export const dropdownListPadding = 5; // px.
+
+/*
+ * Styled Components.
+ */
+
+interface StyledPersistentContainerProps {
+  $height: number;
+}
+
+const StyledPersistentContainer = styled.div<StyledPersistentContainerProps>`
+  height: ${(props) => props.$height}px;
+  overflow: auto;
+  padding: ${dropdownListPadding}px 0;
+  box-sizing: border-box;
+`;
+
+const StyledPersistentItem = styled.div<{ $height: number }>`
+  height: ${(props) => props.$height}px;
+  display: flex;
+  align-items: stretch;
+`;
 
 /*
  * Props.
@@ -37,6 +59,8 @@ interface DropdownListProps {
   renderItem: (index: number) => React.ReactNode;
   /** Called when we should load more items. */
   onLoadMore: () => Promise<void>;
+  /** If true, disables virtualization and renders all items directly. Useful for submenus that need to stay mounted. */
+  isPersistent?: boolean;
 }
 
 type RenderChild = ComponentType<ListChildComponentProps>;
@@ -57,7 +81,8 @@ export const DropdownList: FC<DropdownListProps> = (props) => {
     loadingSkeleton,
     getItemHeight,
     renderItem,
-    onLoadMore
+    onLoadMore,
+    isPersistent
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
@@ -101,6 +126,26 @@ export const DropdownList: FC<DropdownListProps> = (props) => {
     if (!isItemLoaded(index)) return <div style={updateStyle}>{loadingSkeleton}</div>;
     return <div style={updateStyle}>{renderItem(index)}</div>;
   };
+
+  // If isPersistent is true, render without virtualization
+  // This is used for submenus that need to stay mounted for search functionality
+  if (isPersistent)
+    return (
+      <StyledPersistentContainer $height={height}>
+        {Array.from({ length: itemCount }, (_, index) => {
+          const itemHeight = computeItemHeight(index);
+          const isLoaded = isItemLoaded(index);
+          
+          return (
+            <StyledPersistentItem 
+              key={`persistent-item-${index}`} 
+              $height={itemHeight}>
+              {isLoaded ? renderItem(index) : loadingSkeleton}
+            </StyledPersistentItem>
+          );
+        })}
+      </StyledPersistentContainer>
+    );
 
   return (
     <InfiniteLoader

--- a/src/elements/dropdown/hooks/useSubmenuPositioning.ts
+++ b/src/elements/dropdown/hooks/useSubmenuPositioning.ts
@@ -1,0 +1,123 @@
+import {Placement} from '@popperjs/core';
+import {useCallback, useMemo} from 'react';
+
+import {SubmenuPositioning} from '../types/nestedDropdown';
+
+/**
+ * Hook for calculating submenu positioning, z-index, and layer management.
+ * 
+ * This hook provides utilities for:
+ * - Calculating appropriate z-index values based on nesting level
+ * - Generating unique layer IDs for portal rendering
+ * - Creating positioning data for Popper.js integration
+ * 
+ * The z-index calculation ensures that deeper submenus always appear above
+ * their parents, preventing visual overlap issues.
+ */
+
+/**
+ * Configuration options for submenu positioning.
+ */
+interface UseSubmenuPositioningProps {
+  /** Unique ID for this submenu - used for generating layer IDs */
+  submenuId: string;
+  /** Current nesting level (0 = top level, 1 = first nested, etc.) */
+  level: number;
+  /** Preferred Popper.js placement for the submenu */
+  placement?: Placement;
+  /** Prefix for generating unique layer IDs */
+  layerIdPrefix?: string;
+}
+
+/**
+ * Return type for the useSubmenuPositioning hook.
+ */
+interface UseSubmenuPositioningReturn {
+  /** 
+   * Creates positioning data for a submenu relative to its anchor element.
+   * @param anchorElement - The DOM element to position the submenu relative to
+   * @returns Complete positioning configuration for Popper.js
+   */
+  getPositioning: (anchorElement: HTMLElement) => SubmenuPositioning;
+  /** 
+   * Calculates the appropriate z-index for this submenu level.
+   * @param baseZIndex - Optional base z-index (defaults to 1000)
+   * @returns Calculated z-index value
+   */
+  calculateZIndex: (baseZIndex?: number) => number;
+  /** 
+   * Generates a unique layer ID for portal rendering.
+   * @returns Deterministic layer ID string
+   */
+  getLayerId: () => string;
+}
+
+/** Base z-index for top-level submenus */
+const BASE_Z_INDEX = 1000;
+/** Z-index increment per nesting level to ensure proper stacking */
+const Z_INDEX_INCREMENT = 10;
+
+/**
+ * Hook for managing submenu positioning and z-index calculations.
+ * 
+ * @param props - Configuration options for positioning
+ * @returns Object containing positioning utilities
+ * 
+ * @example
+ * ```tsx
+ * const { getPositioning, calculateZIndex, getLayerId } = useSubmenuPositioning({
+ *   submenuId: 'my-submenu',
+ *   level: 1,
+ *   placement: 'right-start',
+ *   layerIdPrefix: 'dropdown'
+ * });
+ * 
+ * // Get positioning for a specific anchor element
+ * const positioning = getPositioning(triggerElement);
+ * 
+ * // Calculate z-index for this level
+ * const zIndex = calculateZIndex(); // Returns 1010 for level 1
+ * 
+ * // Get unique layer ID
+ * const layerId = getLayerId(); // Returns 'dropdown-1-my-submenu'
+ * ```
+ */
+export const useSubmenuPositioning = ({
+  submenuId,
+  level,
+  placement = 'right-start',
+  layerIdPrefix = 'nested-dropdown'
+}: UseSubmenuPositioningProps): UseSubmenuPositioningReturn => {
+  
+  /**
+   * Calculates z-index based on nesting level to ensure proper stacking order.
+   * Each level gets a higher z-index to appear above its parent.
+   */
+  const calculateZIndex = useCallback((baseZIndex = BASE_Z_INDEX): number => 
+    baseZIndex + (level * Z_INDEX_INCREMENT), [level]);
+
+  /**
+   * Generates a deterministic layer ID for consistent portal rendering.
+   * Format: {prefix}-{level}-{submenuId}
+   */
+  const getLayerId = useCallback((): string => 
+    `${layerIdPrefix}-${level}-${submenuId}`, [layerIdPrefix, level, submenuId]);
+
+  /**
+   * Creates complete positioning configuration for a submenu.
+   * Combines anchor element, placement, z-index, and layer ID.
+   */
+  const getPositioning = useCallback((anchorElement: HTMLElement): SubmenuPositioning => ({
+      anchorElement,
+      placement,
+      zIndex: calculateZIndex(),
+      layerId: getLayerId()
+    }), [placement, calculateZIndex, getLayerId]);
+
+  return useMemo(() => ({
+    getPositioning,
+    calculateZIndex,
+    getLayerId
+  }), [getPositioning, calculateZIndex, getLayerId]);
+};
+

--- a/src/elements/dropdown/types/nestedDropdown.ts
+++ b/src/elements/dropdown/types/nestedDropdown.ts
@@ -1,0 +1,101 @@
+import {Placement} from '@popperjs/core';
+import {ReactNode} from 'react';
+
+/**
+ * Configuration for nested dropdown behavior
+ */
+export interface NestedDropdownConfig {
+  /** Delay before opening submenu on hover (ms) */
+  openDelay: number;
+  /** Delay before closing submenu when mouse leaves (ms) */
+  closeDelay: number;
+  /** Maximum nesting depth allowed */
+  maxDepth: number;
+  /** Placement preference for submenus */
+  placement: Placement;
+  /** Whether to use keyboard navigation */
+  enableKeyboardNavigation: boolean;
+  /** Custom layer root ID prefix */
+  layerIdPrefix: string;
+}
+
+/**
+ * Default configuration for nested dropdowns
+ */
+export const DEFAULT_NESTED_CONFIG: NestedDropdownConfig = {
+  openDelay: 150,
+  closeDelay: 300,
+  maxDepth: 3,
+  placement: 'right-start',
+  enableKeyboardNavigation: true,
+  layerIdPrefix: 'nested-dropdown'
+};
+
+/**
+ * State for a single submenu
+ */
+export interface SubmenuState {
+  /** Whether the submenu is currently open */
+  isOpen: boolean;
+  /** Whether the mouse is currently over the submenu area */
+  isHovered: boolean;
+  /** Unique identifier for this submenu */
+  id: string;
+  /** Current nesting level (0 = root) */
+  level: number;
+  /** Parent submenu ID (if any) */
+  parentId?: string;
+}
+
+/**
+ * Context for managing nested dropdown state
+ */
+export interface NestedDropdownContextValue {
+  /** Current configuration */
+  config: NestedDropdownConfig;
+  /** Map of all submenu states */
+  submenus: Map<string, SubmenuState>;
+  /** Open a submenu */
+  openSubmenu: (id: string, parentId?: string) => void;
+  /** Close a submenu */
+  closeSubmenu: (id: string) => void;
+  /** Close all submenus at or below a certain level */
+  closeSubmenusFromLevel: (level: number) => void;
+  /** Set hover state for a submenu */
+  setSubmenuHover: (id: string, isHovered: boolean) => void;
+  /** Get the current nesting level for a submenu */
+  getSubmenuLevel: (id: string) => number;
+  /** Check if maximum depth would be exceeded */
+  canOpenSubmenu: (parentId?: string) => boolean;
+}
+
+/**
+ * Props for components that can have submenus
+ */
+export interface SubmenuCapableProps {
+  /** Unique identifier for this item */
+  submenuId?: string;
+  /** Content to render in the submenu */
+  submenu?: ReactNode;
+  /** Custom configuration for this submenu */
+  submenuConfig?: Partial<NestedDropdownConfig>;
+  /** Called when submenu opens */
+  onSubmenuOpen?: (id: string) => void;
+  /** Called when submenu closes */
+  onSubmenuClose?: (id: string) => void;
+}
+
+/**
+ * Positioning data for a submenu
+ */
+export interface SubmenuPositioning {
+  /** Reference element for positioning */
+  anchorElement: HTMLElement;
+  /** Preferred placement */
+  placement: Placement;
+  /** Z-index for layering */
+  zIndex: number;
+  /** Layer root ID */
+  layerId: string;
+}
+

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -10,6 +10,8 @@ export {DropdownItemFormField} from './dropdown/dropdownItemFormField';
 export {DropdownFooter} from './dropdown/dropdownFooter';
 export {DropdownItemSkeleton} from './dropdown/skeleton/dropdownItemSkeleton';
 export {DropdownItemSpacer} from './dropdown/dropdownItemSpacer';
+export {NestedDropdownContext} from './dropdown/context/NestedDropdownContext';
+export {NestedDropdownProvider} from './dropdown/context/NestedDropdownContext';
 
 export {EmptyState} from './emptyState/emptyState';
 


### PR DESCRIPTION
Implements a multi-level nested dropdown system for the Front UI Kit, enabling dropdowns to contain submenus with configurable nesting depth, hover interactions, and smooth positioning.

This is a new design requirement, and is yet to be implemented in the Front client yet. 


### New Components & Hooks

#### **Context System**

- `NestedDropdownContext` - Centralized state management for all submenus
- `NestedDropdownProvider` - Provider component with configuration options
- `useNestedDropdown` - Hook to access context
- `useSubmenu` - Hook for individual submenu management

#### **Positioning System**

- `useSubmenuPositioning` - Z-index calculation and layer management
- `SubmenuTrigger` - Core component handling submenu interactions and positioning

### 🎯 Key Design Decisions

1. **Direct Popper.js Integration**: Bypasses `PopoverContext` to avoid anchor conflicts
3. **Persistent Rendering**: Non-virtualized mode preserves submenu state (search inputs, etc.)
4. **Level-Based Z-Index**: Automatic stacking order based on nesting depth