### PR TITLE
feat: adding offset props for dropdown

### DIFF
--- a/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
+++ b/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
@@ -1,4 +1,4 @@
-import {type Placement,placements} from '@popperjs/core';
+import {type Placement, placements} from '@popperjs/core';
 import type {StoryFn} from '@storybook/react';
 import React, {useState} from 'react';
 import styled from 'styled-components';
@@ -261,7 +261,7 @@ const MultiSelectTemplate: StoryFn = ({placement, offset}) => {
         <NestedDropdownProvider
           config={{
             openDelay: 200,
-            closeDelay: 40000,
+            closeDelay: 400,
             maxDepth: 3,
             placement
           }}>

--- a/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
+++ b/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
@@ -2,9 +2,11 @@ import type {StoryFn} from '@storybook/react';
 import React, {useState} from 'react';
 import styled from 'styled-components';
 
+import {type Placement, placements} from '@popperjs/core';
 import {palette} from '../../../../helpers/colorHelpers';
 import {EmptyState} from '../../../emptyState/emptyState';
 import {NestedDropdownProvider} from '../../context/NestedDropdownContext';
+import {NestedDropdownConfig} from '../../types/nestedDropdown';
 import {Dropdown} from '../../dropdown';
 import {DropdownButton} from '../../dropdownButton';
 import {DropdownCoordinator} from '../../dropdownCoordinator';
@@ -123,7 +125,11 @@ const departmentsData = [
   }
 ];
 
-const Template: StoryFn = () => {
+type NestedDropdownStoryArgs = {
+  placement: Placement;
+}
+
+const Template: StoryFn<NestedDropdownStoryArgs> = () => {
   const [selectedValue, setSelectedValue] = useState('');
   const [submenuSearchValues, setSubmenuSearchValues] = useState<Record<string, string>>({});
   const [filteredSubmenuItems, setFilteredSubmenuItems] = useState<Record<string, string[]>>({});
@@ -229,7 +235,7 @@ CustomConfigDropdown.decorators = [
 ];
 
 // Multi-select nested dropdown example
-const MultiSelectTemplate: StoryFn = () => {
+const MultiSelectTemplate: StoryFn = ({ placement, offset }) => {
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
   const [submenuSearchValues, setSubmenuSearchValues] = useState<Record<string, string>>({});
 
@@ -256,9 +262,9 @@ const MultiSelectTemplate: StoryFn = () => {
         <NestedDropdownProvider
           config={{
             openDelay: 200,
-            closeDelay: 400,
+            closeDelay: 40000,
             maxDepth: 3,
-            placement: 'right-start'
+            placement,
           }}>
           <DropdownCoordinator
             placement="bottom-start"
@@ -326,7 +332,9 @@ const MultiSelectTemplate: StoryFn = () => {
                             </DropdownItem>
                           ))}
                         </Dropdown>
-                      }>
+                      }
+                      submenuConfig={{ offset }}
+                      >
                       <DropdownItemIcon
                         color={palette.purple.shade40}
                         iconName={category.icon as 'Archive' | 'Star' | 'Calendar'}
@@ -346,6 +354,24 @@ const MultiSelectTemplate: StoryFn = () => {
 
 export const MultiSelectDropdown = MultiSelectTemplate.bind({});
 MultiSelectDropdown.storyName = 'Multi-Select with Submenus';
+MultiSelectDropdown.args = {
+  placement: 'right-start',
+  offset: {
+    skidding: 0,
+    distance: 8
+  }
+};
+
+MultiSelectDropdown.argTypes = {
+  placement: {
+    control: 'select',
+    options: placements
+  },
+  offset: {
+    control: 'object',
+    description: 'Offset for the submenu positioning',
+  }
+};
 
 // Left-aligned submenu example
 const LeftAlignedTemplate: StoryFn = () => (

--- a/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
+++ b/src/elements/dropdown/__docs__/stories/nestedDropdown.stories.tsx
@@ -1,12 +1,11 @@
+import {type Placement,placements} from '@popperjs/core';
 import type {StoryFn} from '@storybook/react';
 import React, {useState} from 'react';
 import styled from 'styled-components';
 
-import {type Placement, placements} from '@popperjs/core';
 import {palette} from '../../../../helpers/colorHelpers';
 import {EmptyState} from '../../../emptyState/emptyState';
 import {NestedDropdownProvider} from '../../context/NestedDropdownContext';
-import {NestedDropdownConfig} from '../../types/nestedDropdown';
 import {Dropdown} from '../../dropdown';
 import {DropdownButton} from '../../dropdownButton';
 import {DropdownCoordinator} from '../../dropdownCoordinator';
@@ -127,7 +126,7 @@ const departmentsData = [
 
 type NestedDropdownStoryArgs = {
   placement: Placement;
-}
+};
 
 const Template: StoryFn<NestedDropdownStoryArgs> = () => {
   const [selectedValue, setSelectedValue] = useState('');
@@ -235,7 +234,7 @@ CustomConfigDropdown.decorators = [
 ];
 
 // Multi-select nested dropdown example
-const MultiSelectTemplate: StoryFn = ({ placement, offset }) => {
+const MultiSelectTemplate: StoryFn = ({placement, offset}) => {
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
   const [submenuSearchValues, setSubmenuSearchValues] = useState<Record<string, string>>({});
 
@@ -264,7 +263,7 @@ const MultiSelectTemplate: StoryFn = ({ placement, offset }) => {
             openDelay: 200,
             closeDelay: 40000,
             maxDepth: 3,
-            placement,
+            placement
           }}>
           <DropdownCoordinator
             placement="bottom-start"
@@ -333,8 +332,7 @@ const MultiSelectTemplate: StoryFn = ({ placement, offset }) => {
                           ))}
                         </Dropdown>
                       }
-                      submenuConfig={{ offset }}
-                      >
+                      submenuConfig={{offset}}>
                       <DropdownItemIcon
                         color={palette.purple.shade40}
                         iconName={category.icon as 'Archive' | 'Star' | 'Calendar'}
@@ -369,7 +367,7 @@ MultiSelectDropdown.argTypes = {
   },
   offset: {
     control: 'object',
-    description: 'Offset for the submenu positioning',
+    description: 'Offset for the submenu positioning'
   }
 };
 

--- a/src/elements/dropdown/components/SubmenuTrigger.tsx
+++ b/src/elements/dropdown/components/SubmenuTrigger.tsx
@@ -257,9 +257,9 @@ interface SubmenuPortalProps {
   maxWidth: string;
 }
 
-const DEFAULT_LEFT_OFFSET = 0;
-const DEFAULT_TOP_OFFSET = 8;
-const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => [incomingOffset?.left ?? DEFAULT_LEFT_OFFSET, incomingOffset?.top ?? DEFAULT_TOP_OFFSET]
+const DEFAULT_SKIDDING_OFFSET = 0;
+const DEFAULT_DISTANCE_OFFSET = 8;
+const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => [incomingOffset?.skidding ?? DEFAULT_SKIDDING_OFFSET, incomingOffset?.distance ?? DEFAULT_DISTANCE_OFFSET]
 
 /**
  * SubmenuPortal renders the submenu in a portal with custom Popper.js positioning.

--- a/src/elements/dropdown/components/SubmenuTrigger.tsx
+++ b/src/elements/dropdown/components/SubmenuTrigger.tsx
@@ -259,9 +259,7 @@ interface SubmenuPortalProps {
 
 const DEFAULT_LEFT_OFFSET = 0;
 const DEFAULT_TOP_OFFSET = 8;
-const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => {
-  return [incomingOffset?.left ?? DEFAULT_LEFT_OFFSET, incomingOffset?.top ?? DEFAULT_TOP_OFFSET];
-}
+const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => [incomingOffset?.left ?? DEFAULT_LEFT_OFFSET, incomingOffset?.top ?? DEFAULT_TOP_OFFSET]
 
 /**
  * SubmenuPortal renders the submenu in a portal with custom Popper.js positioning.

--- a/src/elements/dropdown/components/SubmenuTrigger.tsx
+++ b/src/elements/dropdown/components/SubmenuTrigger.tsx
@@ -259,7 +259,10 @@ interface SubmenuPortalProps {
 
 const DEFAULT_SKIDDING_OFFSET = 0;
 const DEFAULT_DISTANCE_OFFSET = 8;
-const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => [incomingOffset?.skidding ?? DEFAULT_SKIDDING_OFFSET, incomingOffset?.distance ?? DEFAULT_DISTANCE_OFFSET]
+const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => [
+  incomingOffset?.skidding ?? DEFAULT_SKIDDING_OFFSET,
+  incomingOffset?.distance ?? DEFAULT_DISTANCE_OFFSET
+];
 
 /**
  * SubmenuPortal renders the submenu in a portal with custom Popper.js positioning.

--- a/src/elements/dropdown/components/SubmenuTrigger.tsx
+++ b/src/elements/dropdown/components/SubmenuTrigger.tsx
@@ -1,4 +1,5 @@
 import {type Placement} from '@popperjs/core';
+import {type Options} from '@popperjs/core/lib/modifiers/offset';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {usePopper} from 'react-popper';
 import {styled} from 'styled-components';
@@ -6,7 +7,7 @@ import {styled} from 'styled-components';
 import {Layer} from '../../../components/layer/layer';
 import {useNestedDropdown, useSubmenu} from '../context/NestedDropdownContext';
 import {useSubmenuPositioning} from '../hooks/useSubmenuPositioning';
-import {SubmenuCapableProps} from '../types/nestedDropdown';
+import {SubmenuCapableProps, SubmenuOffset} from '../types/nestedDropdown';
 
 interface SubmenuTriggerProps extends SubmenuCapableProps {
   children: React.ReactNode;
@@ -115,7 +116,8 @@ export const SubmenuTrigger: React.FC<SubmenuTriggerProps> = ({
     submenuId: effectiveSubmenuId,
     level,
     placement: effectiveConfig.placement,
-    layerIdPrefix: effectiveConfig.layerIdPrefix
+    layerIdPrefix: effectiveConfig.layerIdPrefix,
+    offset: effectiveConfig.offset
   });
 
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -244,6 +246,7 @@ interface SubmenuPortalProps {
     placement: Placement;
     zIndex: number;
     layerId: string;
+    offset?: SubmenuOffset;
   };
   onMouseEnter: () => void;
   onMouseLeave: () => void;
@@ -252,6 +255,12 @@ interface SubmenuPortalProps {
   children: React.ReactNode;
   minWidth: string;
   maxWidth: string;
+}
+
+const DEFAULT_LEFT_OFFSET = 0;
+const DEFAULT_TOP_OFFSET = 8;
+const toPopperOffset = (incomingOffset?: SubmenuOffset): Options['offset'] => {
+  return [incomingOffset?.left ?? DEFAULT_LEFT_OFFSET, incomingOffset?.top ?? DEFAULT_TOP_OFFSET];
 }
 
 /**
@@ -295,7 +304,7 @@ const SubmenuPortal: React.FC<SubmenuPortalProps> = ({
       {
         name: 'offset',
         options: {
-          offset: [0, 8] // 8px gap between trigger and submenu
+          offset: toPopperOffset(positioning.offset) // 8px gap between trigger and submenu
         }
       },
       {

--- a/src/elements/dropdown/hooks/useSubmenuPositioning.ts
+++ b/src/elements/dropdown/hooks/useSubmenuPositioning.ts
@@ -89,7 +89,7 @@ export const useSubmenuPositioning = ({
   level,
   placement = 'right-start',
   layerIdPrefix = 'nested-dropdown',
-  offset,
+  offset
 }: UseSubmenuPositioningProps): UseSubmenuPositioningReturn => {
   /**
    * Calculates z-index based on nesting level to ensure proper stacking order.

--- a/src/elements/dropdown/hooks/useSubmenuPositioning.ts
+++ b/src/elements/dropdown/hooks/useSubmenuPositioning.ts
@@ -1,7 +1,7 @@
 import {Placement} from '@popperjs/core';
 import {useCallback, useMemo} from 'react';
 
-import {SubmenuPositioning} from '../types/nestedDropdown';
+import {SubmenuPositioning, SubmenuOffset} from '../types/nestedDropdown';
 
 /**
  * Hook for calculating submenu positioning, z-index, and layer management.
@@ -27,6 +27,8 @@ interface UseSubmenuPositioningProps {
   placement?: Placement;
   /** Prefix for generating unique layer IDs */
   layerIdPrefix?: string;
+  /** Offset for submenu positioning */
+  offset?: SubmenuOffset;
 }
 
 /**
@@ -86,7 +88,8 @@ export const useSubmenuPositioning = ({
   submenuId,
   level,
   placement = 'right-start',
-  layerIdPrefix = 'nested-dropdown'
+  layerIdPrefix = 'nested-dropdown',
+  offset,
 }: UseSubmenuPositioningProps): UseSubmenuPositioningReturn => {
   /**
    * Calculates z-index based on nesting level to ensure proper stacking order.
@@ -115,9 +118,10 @@ export const useSubmenuPositioning = ({
       anchorElement,
       placement,
       zIndex: calculateZIndex(),
-      layerId: getLayerId()
+      layerId: getLayerId(),
+      offset
     }),
-    [placement, calculateZIndex, getLayerId]
+    [placement, calculateZIndex, getLayerId, offset]
   );
 
   return useMemo(

--- a/src/elements/dropdown/hooks/useSubmenuPositioning.ts
+++ b/src/elements/dropdown/hooks/useSubmenuPositioning.ts
@@ -1,7 +1,7 @@
 import {Placement} from '@popperjs/core';
 import {useCallback, useMemo} from 'react';
 
-import {SubmenuPositioning, SubmenuOffset} from '../types/nestedDropdown';
+import {SubmenuOffset, SubmenuPositioning} from '../types/nestedDropdown';
 
 /**
  * Hook for calculating submenu positioning, z-index, and layer management.

--- a/src/elements/dropdown/types/nestedDropdown.ts
+++ b/src/elements/dropdown/types/nestedDropdown.ts
@@ -105,6 +105,6 @@ export interface SubmenuPositioning {
 
 
 export interface SubmenuOffset {
-  left?: number;
-  top?: number;
+  skidding?: number;
+  distance?: number;
 }

--- a/src/elements/dropdown/types/nestedDropdown.ts
+++ b/src/elements/dropdown/types/nestedDropdown.ts
@@ -17,6 +17,8 @@ export interface NestedDropdownConfig {
   enableKeyboardNavigation: boolean;
   /** Custom layer root ID prefix */
   layerIdPrefix: string;
+  /** Offset for submenu positioning */
+  offset?: SubmenuOffset;
 }
 
 /**
@@ -28,7 +30,7 @@ export const DEFAULT_NESTED_CONFIG: NestedDropdownConfig = {
   maxDepth: 3,
   placement: 'right-start',
   enableKeyboardNavigation: true,
-  layerIdPrefix: 'nested-dropdown'
+  layerIdPrefix: 'nested-dropdown',
 };
 
 /**
@@ -97,4 +99,12 @@ export interface SubmenuPositioning {
   zIndex: number;
   /** Layer root ID */
   layerId: string;
+  /** Offset for submenu positioning */
+  offset?: SubmenuOffset;
+}
+
+
+export interface SubmenuOffset {
+  left?: number;
+  top?: number;
 }


### PR DESCRIPTION
## Description

I added support to pass offset.skidding and offset.distance for offset react-popper prop.

This will allow us to move a popper dropdown as a whole instead of using css, why ? using css won't resolve the root problem, it we're moving using css (relative positions with left, right or adding paddings or margins) because it will only display the content component but not the layer itself.

using css will keep the layer where it's created and it will overlap content behind and as a result it will avoid pointer events behind elements.

## Screenshot

I added some storybook args for the nested dropdown component, so now we can use storybook for testing this new config props (for submenu only)

<img width="905" height="681" alt="Screenshot 2026-06-16 at 12 53 25 PM" src="https://github.com/user-attachments/assets/51362d63-33ae-4ea4-ba10-0b081031377d" />
